### PR TITLE
clean architecture 구조로 설계 및 설문조사 생성 API 개발 준비.

### DIFF
--- a/project/junbeom-onboarding/src/main/java/com/fastcampus/survey/questionary/adapter/in/SurveyFormController.java
+++ b/project/junbeom-onboarding/src/main/java/com/fastcampus/survey/questionary/adapter/in/SurveyFormController.java
@@ -1,0 +1,24 @@
+package com.fastcampus.survey.questionary.adapter.in;
+
+import com.fastcampus.survey.questionary.domain.model.SurveyForm;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.fastcampus.survey.questionary.adapter.in.dto.InsertFormRequest;
+import com.fastcampus.survey.questionary.application.SurveyFormService;
+
+@RestController
+@RequestMapping("/api/surveys")
+@RequiredArgsConstructor
+public class SurveyFormController {
+    private final SurveyFormService surveyFormService;
+
+    @PostMapping
+    public SurveyForm createSurvey(@RequestBody InsertFormRequest insertFormRequest) {
+        return surveyFormService.createSurveyForm(insertFormRequest);
+    }
+
+} 

--- a/project/junbeom-onboarding/src/main/java/com/fastcampus/survey/questionary/adapter/in/dto/InsertContentRequest.java
+++ b/project/junbeom-onboarding/src/main/java/com/fastcampus/survey/questionary/adapter/in/dto/InsertContentRequest.java
@@ -1,0 +1,20 @@
+package com.fastcampus.survey.questionary.adapter.in.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.AllArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class InsertContentRequest {
+
+    private String name;
+    private String describe;
+    private String type;
+    private boolean isRequired;
+    private List<String> options;
+
+}

--- a/project/junbeom-onboarding/src/main/java/com/fastcampus/survey/questionary/adapter/in/dto/InsertFormRequest.java
+++ b/project/junbeom-onboarding/src/main/java/com/fastcampus/survey/questionary/adapter/in/dto/InsertFormRequest.java
@@ -1,0 +1,19 @@
+package com.fastcampus.survey.questionary.adapter.in.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.AllArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class InsertFormRequest {
+
+    private String name;
+    private String describe;
+    private List<InsertContentRequest> contents;
+
+
+}

--- a/project/junbeom-onboarding/src/main/java/com/fastcampus/survey/questionary/adapter/in/mapper/SurveyFormMapper.java
+++ b/project/junbeom-onboarding/src/main/java/com/fastcampus/survey/questionary/adapter/in/mapper/SurveyFormMapper.java
@@ -1,0 +1,7 @@
+package com.fastcampus.survey.questionary.adapter.in.mapper;
+
+public class SurveyFormMapper {
+
+    // TODO: Mapper 구현..
+
+} 

--- a/project/junbeom-onboarding/src/main/java/com/fastcampus/survey/questionary/adapter/out/entity/SurveyContentJpaEntity.java
+++ b/project/junbeom-onboarding/src/main/java/com/fastcampus/survey/questionary/adapter/out/entity/SurveyContentJpaEntity.java
@@ -1,0 +1,34 @@
+package com.fastcampus.survey.questionary.adapter.out.entity;
+
+import jakarta.persistence.*;
+import java.util.List;
+
+@Entity
+@Table(name = "survey_content")
+public class SurveyContentJpaEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "form_id")
+    private SurveyFormJpaEntity form;
+
+    @Column(nullable = false, length = 50)
+    private String name;
+
+    @Column(length = 50)
+    private String describe;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    private SurveyContentType type;
+
+    @Column(nullable = false)
+    private boolean isRequired;
+
+    @OneToMany(mappedBy = "content", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<SurveyContentOptionJpaEntity> options;
+
+    // getter, setter, 생성자 등
+} 

--- a/project/junbeom-onboarding/src/main/java/com/fastcampus/survey/questionary/adapter/out/entity/SurveyContentOptionJpaEntity.java
+++ b/project/junbeom-onboarding/src/main/java/com/fastcampus/survey/questionary/adapter/out/entity/SurveyContentOptionJpaEntity.java
@@ -1,0 +1,28 @@
+package com.fastcampus.survey.questionary.adapter.out.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+
+@Entity
+@Table(name = "survey_content_option")
+public class SurveyContentOptionJpaEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "content_id")
+    private SurveyContentJpaEntity content;
+
+    @Column(length = 100)
+    private String text;
+
+    // getter, setter, 생성자 등
+} 

--- a/project/junbeom-onboarding/src/main/java/com/fastcampus/survey/questionary/adapter/out/entity/SurveyContentType.java
+++ b/project/junbeom-onboarding/src/main/java/com/fastcampus/survey/questionary/adapter/out/entity/SurveyContentType.java
@@ -1,0 +1,8 @@
+package com.fastcampus.survey.questionary.adapter.out.entity;
+
+public enum SurveyContentType {
+    SHORT_ANSWER,
+    LONG_ANSWER,
+    RADIO,
+    CHECK_BOX
+} 

--- a/project/junbeom-onboarding/src/main/java/com/fastcampus/survey/questionary/adapter/out/entity/SurveyFormJpaEntity.java
+++ b/project/junbeom-onboarding/src/main/java/com/fastcampus/survey/questionary/adapter/out/entity/SurveyFormJpaEntity.java
@@ -1,0 +1,27 @@
+package com.fastcampus.survey.questionary.adapter.out.entity;
+
+import jakarta.persistence.*;
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Entity
+@Table(name = "survey_form")
+public class SurveyFormJpaEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, length = 50)
+    private String name;
+
+    @Column(length = 100)
+    private String describe;
+
+    @Column(name = "create_at")
+    private LocalDateTime createAt;
+
+    @OneToMany(mappedBy = "form", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<SurveyContentJpaEntity> contents;
+
+    // getter, setter, 생성자 등
+} 

--- a/project/junbeom-onboarding/src/main/java/com/fastcampus/survey/questionary/adapter/out/impl/SurveyFormRepositoryImpl.java
+++ b/project/junbeom-onboarding/src/main/java/com/fastcampus/survey/questionary/adapter/out/impl/SurveyFormRepositoryImpl.java
@@ -1,0 +1,31 @@
+package com.fastcampus.survey.questionary.adapter.out.impl;
+
+import com.fastcampus.survey.questionary.domain.model.SurveyForm;
+import com.fastcampus.survey.questionary.domain.repository.SurveyFormRepository;
+import com.fastcampus.survey.questionary.adapter.out.repository.SurveyFormJpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public class SurveyFormRepositoryImpl implements SurveyFormRepository {
+    private final SurveyFormJpaRepository jpaRepository;
+
+    public SurveyFormRepositoryImpl(SurveyFormJpaRepository jpaRepository) {
+        this.jpaRepository = jpaRepository;
+    }
+
+    @Override
+    public SurveyForm save(SurveyForm form) {
+        // TODO: SurveyForm <-> SurveyFormJpaEntity 매핑 필요
+        // 임시로 null 반환
+        return null;
+    }
+
+    @Override
+    public Optional<SurveyForm> findById(Long id) {
+        // TODO: SurveyFormJpaEntity <-> SurveyForm 매핑 필요
+        // 임시로 Optional.empty() 반환
+        return Optional.empty();
+    }
+} 

--- a/project/junbeom-onboarding/src/main/java/com/fastcampus/survey/questionary/adapter/out/repository/SurveyFormJpaRepository.java
+++ b/project/junbeom-onboarding/src/main/java/com/fastcampus/survey/questionary/adapter/out/repository/SurveyFormJpaRepository.java
@@ -1,0 +1,8 @@
+package com.fastcampus.survey.questionary.adapter.out.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.fastcampus.survey.questionary.adapter.out.entity.SurveyFormJpaEntity;
+
+public interface SurveyFormJpaRepository extends JpaRepository<SurveyFormJpaEntity, Long> {
+} 

--- a/project/junbeom-onboarding/src/main/java/com/fastcampus/survey/questionary/application/SurveyFormService.java
+++ b/project/junbeom-onboarding/src/main/java/com/fastcampus/survey/questionary/application/SurveyFormService.java
@@ -1,0 +1,27 @@
+package com.fastcampus.survey.questionary.application;
+
+import com.fastcampus.survey.questionary.adapter.in.dto.InsertFormRequest;
+import com.fastcampus.survey.questionary.domain.model.SurveyForm;
+import com.fastcampus.survey.questionary.domain.repository.SurveyFormRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class SurveyFormService {
+
+    private final SurveyFormRepository surveyFormRepository;
+
+    public SurveyForm createSurveyForm(InsertFormRequest insertFormRequest) {
+        SurveyForm surveyForm = new SurveyForm(insertFormRequest);
+        return surveyFormRepository.save(surveyForm);
+    }
+
+    public SurveyForm updateSurveyForm(Long id, SurveyForm form) {
+        // 수정 로직, 검증 등
+        // ...
+        return surveyFormRepository.save(form);
+    }
+
+    // 기타 유스케이스 메서드
+} 

--- a/project/junbeom-onboarding/src/main/java/com/fastcampus/survey/questionary/domain/model/SurveyContent.java
+++ b/project/junbeom-onboarding/src/main/java/com/fastcampus/survey/questionary/domain/model/SurveyContent.java
@@ -1,0 +1,19 @@
+package com.fastcampus.survey.questionary.domain.model;
+
+import lombok.Getter;
+
+
+import java.util.List;
+
+@Getter
+public class SurveyContent {
+    private Long id;
+    private Long formId;
+    private String name;
+    private String describe;
+    private SurveyContentType type;
+    private boolean isRequired;
+    private List<SurveyContentOption> options;
+
+
+} 

--- a/project/junbeom-onboarding/src/main/java/com/fastcampus/survey/questionary/domain/model/SurveyContentOption.java
+++ b/project/junbeom-onboarding/src/main/java/com/fastcampus/survey/questionary/domain/model/SurveyContentOption.java
@@ -1,0 +1,14 @@
+package com.fastcampus.survey.questionary.domain.model;
+
+
+import lombok.Getter;
+
+
+@Getter
+public class SurveyContentOption {
+
+    private Long id;
+    private Long contentId;
+    private String text;
+
+}

--- a/project/junbeom-onboarding/src/main/java/com/fastcampus/survey/questionary/domain/model/SurveyContentType.java
+++ b/project/junbeom-onboarding/src/main/java/com/fastcampus/survey/questionary/domain/model/SurveyContentType.java
@@ -1,0 +1,8 @@
+package com.fastcampus.survey.questionary.domain.model;
+
+public enum SurveyContentType {
+    SHORT_ANSWER,
+    LONG_ANSWER,
+    RADIO,
+    CHECK_BOX
+} 

--- a/project/junbeom-onboarding/src/main/java/com/fastcampus/survey/questionary/domain/model/SurveyForm.java
+++ b/project/junbeom-onboarding/src/main/java/com/fastcampus/survey/questionary/domain/model/SurveyForm.java
@@ -1,0 +1,20 @@
+package com.fastcampus.survey.questionary.domain.model;
+
+import com.fastcampus.survey.questionary.adapter.in.dto.InsertFormRequest;
+import lombok.Builder;
+import lombok.Getter;
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Getter
+public class SurveyForm {
+    private Long id;
+    private String name;
+    private String describe;
+    private LocalDateTime createAt;
+    private List<SurveyContent> contents;
+
+    public SurveyForm(InsertFormRequest insertFormRequest) {
+        // TODO: 비즈니스 로직 처리
+    }
+} 

--- a/project/junbeom-onboarding/src/main/java/com/fastcampus/survey/questionary/domain/repository/SurveyFormRepository.java
+++ b/project/junbeom-onboarding/src/main/java/com/fastcampus/survey/questionary/domain/repository/SurveyFormRepository.java
@@ -1,0 +1,11 @@
+package com.fastcampus.survey.questionary.domain.repository;
+
+import java.util.Optional;
+
+import com.fastcampus.survey.questionary.domain.model.SurveyForm;
+
+public interface SurveyFormRepository {
+    SurveyForm save(SurveyForm form);
+    Optional<SurveyForm> findById(Long id);
+    // 기타 필요한 메서드
+} 


### PR DESCRIPTION

## Goal

- 설문조사 서비스의 클린 아키텍처 기반 초기 설계 및 코드 구조화
- 도메인, 애플리케이션, 어댑터 계층 분리 및 역할별 디렉토리 구조 적용
- 설문지(질문지) 작성/관리 영역의 도메인 모델, 레포지토리, JPA 엔티티, DTO, 매퍼, 컨트롤러 등 기본 뼈대 구현

## Changes
- 클린 아키텍처 원칙에 따라 패키지/디렉토리 구조를 역할별로 세분화
- - domain/model, domain/repository, adapter/out/entity, adapter/out/repository, adapter/out/impl 등
- 설문지(질문지) 관련 도메인 엔티티 및 레포지토리 인터페이스 구현
- JPA 엔티티, Spring Data JPA Repository, 도메인 레포지토리 구현체 분리 및 생성
- 설문 생성/수정용 DTO(InsertFormRequest, UpdateFormRequest 등) 및 매퍼 구현
- 컨트롤러에서 DTO를 받아 도메인 객체로 변환 후 서비스에 전달하는 구조 적용
- Lombok을 활용한 코드 간결화 및 생성자/Getter 자동화
<!-- Describe the changes made in this PR -->

## Description
- 클린 아키텍처 구조 적용
도메인, 애플리케이션, 어댑터 계층을 명확히 분리하여 유지보수성과 확장성을 높임.
- 패키지 구조 리팩토링
entity, repository, impl, model 등 역할별로 디렉토리 분리.
- 설문지 도메인 모델 및 JPA 엔티티 구현
SurveyForm, SurveyContent, SurveyContentOption 등 도메인/엔티티 클래스 구현.
- DTO 및 매퍼 도입
API 요청/응답과 도메인 모델을 분리하여 계층 간 의존성 최소화.
- 컨트롤러/서비스/레포지토리 계층 분리
각 계층별 책임을 명확히 하여 코드 가독성 및 테스트 용이성 확보.
<!-- Describe the changes made in this PR -->

## Additional Context (Optional)

- 추후 설문 응답 영역, 매핑 로직, 예외 처리, 테스트 코드 등 추가 구현 예정
- 클린 아키텍처/DDD 원칙에 따라 구조를 계속 개선할 계획

<!-- Add any additional context or information here -->

## Screenshots/Videos (Optional)

<!-- Add screenshots if applicable -->

## References (Optional)

<!-- Add references like GitHub Issue, related PRs, etc. -->

