### PR TITLE
[2025-06-12]설문조사 생성 API 구현 

### DIFF
--- a/project/jooeun-onboarding/README.md
+++ b/project/jooeun-onboarding/README.md
@@ -1,277 +1,175 @@
-#  Survey Service - 설문조사 서비스
+package com.innercircle.survey.api.controller;
 
-##  프로젝트 개요
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.innercircle.survey.api.dto.request.CreateQuestionRequest;
+import com.innercircle.survey.api.dto.request.CreateSurveyRequest;
+import com.innercircle.survey.api.service.SurveyService;
+import com.innercircle.survey.common.domain.QuestionType;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
 
-설문조사 양식을 만들고, 만들어진 양식을 기반으로 응답을 받을 수 있는 서비스입니다.
+import java.util.List;
 
-## 🏗 아키텍처
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
-### 멀티모듈 구조 (우대사항 적용)
-```
-jooeun-onboarding/
-├── survey-api/              # 웹 레이어 (REST API, 문서화)
-├── survey-domain/           # 도메인 로직 (엔티티, 비즈니스 규칙)
-├── survey-infrastructure/   # 데이터 액세스 (Repository, JPA)
-└── survey-common/          # 공통 유틸리티 (ULID, 상수)
-```
+/**
+ * 설문조사 컨트롤러 단위 테스트
+ */
+@WebMvcTest(SurveyController.class)
+@DisplayName("설문조사 컨트롤러 테스트")
+class SurveyControllerTest {
 
-### 의존성 방향 제약
-```
-survey-api → survey-infrastructure → survey-domain → survey-common
-```
-각 모듈은 하위 레벨 모듈만 의존하며, 순환 의존성이 발생하지 않도록 설계했습니다.
+    @Autowired
+    private MockMvc mockMvc;
 
-## ️ 사용된 기술 스택 및 오픈소스
+    @Autowired
+    private ObjectMapper objectMapper;
 
-### **Core Framework**
-| 라이브러리 | 버전 | 사용 목적 | 요구사항 |
-|-----------|------|----------|---------|
-| **Spring Boot** | 3.2.0 | • 애플리케이션 기본 프레임워크<br>• 자동 설정을 통한 개발 생산성 향상 | ✅ 필수 |
-| **Spring Data JPA** | 3.2.0 | • 데이터베이스 접근 계층 추상화<br>• JPA 기반 데이터 처리 | ✅ 필수 |
-| **QueryDSL** | 5.0.0 | • 타입 안전한 동적 쿼리 생성<br>• Advanced 검색 기능 구현 | 🔍 Advanced |
+    @MockBean
+    private SurveyService surveyService;
 
-### **Database**
-| 라이브러리 | 버전 | 사용 목적 | 요구사항 |
-|-----------|------|----------|---------|
-| **H2 Database** | Latest | • 인메모리 데이터베이스<br>• 개발/테스트 환경용 | ✅ 필수 |
+    @Test
+    @DisplayName("올바른 설문조사 생성 요청 시 201 Created 응답")
+    void 올바른_설문조사_생성_요청_성공() throws Exception {
+        // Given
+        CreateSurveyRequest request = new CreateSurveyRequest(
+                "2024년 고객 만족도 조사",
+                "고객 서비스 개선을 위한 만족도 조사입니다.",
+                List.of(
+                        new CreateQuestionRequest(
+                                "전반적인 서비스에 만족하십니까?",
+                                "서비스 전반에 대한 만족도를 평가해 주세요.",
+                                QuestionType.SINGLE_CHOICE,
+                                true,
+                                List.of("매우 불만족", "불만족", "보통", "만족", "매우 만족")
+                        ),
+                        new CreateQuestionRequest(
+                                "추가 의견이 있으시면 자유롭게 작성해 주세요.",
+                                "더 나은 서비스를 위한 소중한 의견을 들려주세요.",
+                                QuestionType.LONG_TEXT,
+                                false,
+                                null
+                        )
+                )
+        );
 
-### **ID Generation**
-| 라이브러리 | 버전 | 사용 목적 | 요구사항 |
-|-----------|------|----------|---------|
-| **Sulky ULID** | 8.3.0 | • 분산 환경에서 고유 ID 생성<br>• 시간 기반 정렬 가능<br>• 다중 인스턴스에서 충돌 방지 | 🏆 우대사항 |
+        // When & Then
+        mockMvc.perform(post("/api/surveys")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andDo(print())
+                .andExpect(status().isCreated());
+    }
 
-### **API Documentation**
-| 라이브러리 | 버전 | 사용 목적 | 요구사항 |
-|-----------|------|----------|---------|
-| **SpringDoc OpenAPI** | 2.2.0 | • API 문서 자동 생성<br>• Swagger UI 제공<br>• API 명세 제출 요구사항 충족 | ✅ 필수 |
+    @Test
+    @DisplayName("제목이 없는 설문조사 생성 요청 시 400 Bad Request 응답")
+    void 제목_없는_설문조사_생성_요청_실패() throws Exception {
+        // Given
+        CreateSurveyRequest request = new CreateSurveyRequest(
+                "", // 빈 제목
+                "설명",
+                List.of(
+                        new CreateQuestionRequest(
+                                "질문 제목",
+                                "질문 설명",
+                                QuestionType.SHORT_TEXT,
+                                true,
+                                null
+                        )
+                )
+        );
 
-### **Validation & Utility**
-| 라이브러리 | 버전 | 사용 목적 | 요구사항 |
-|-----------|------|----------|---------|
-| **Bean Validation** | 3.0 | • 요청 데이터 검증<br>• 비즈니스 규칙 검증 | ✅ 필수 |
-| **Apache Commons Lang** | 3.14.0 | • 문자열, 유틸리티 함수<br>• 코드 간소화 | 🔧 유틸리티 |
-| **Lombok** | Latest | • 보일러플레이트 코드 제거<br>• 코드 가독성 향상 | 🔧 유틸리티 |
+        // When & Then
+        mockMvc.perform(post("/api/surveys")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andDo(print())
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.error").value("VALIDATION_FAILED"));
+    }
 
-### **Monitoring**
-| 라이브러리 | 버전 | 사용 목적 | 요구사항 |
-|-----------|------|----------|---------|
-| **Spring Boot Actuator** | 3.2.0 | • 애플리케이션 헬스체크<br>• 운영 환경 모니터링 | 🏆 우대사항 |
+    @Test
+    @DisplayName("질문이 없는 설문조사 생성 요청 시 400 Bad Request 응답")
+    void 질문_없는_설문조사_생성_요청_실패() throws Exception {
+        // Given
+        CreateSurveyRequest request = new CreateSurveyRequest(
+                "설문조사 제목",
+                "설문조사 설명",
+                List.of() // 빈 질문 리스트
+        );
 
-### **Testing**
-| 라이브러리 | 버전 | 사용 목적 | 요구사항 |
-|-----------|------|----------|---------|
-| **JUnit 5** | 5.10.1 | • 단위 테스트 프레임워크<br>• 파라미터화 테스트, Nested 테스트 | ✅ 필수 |
-| **AssertJ** | 3.24.2 | • 유창한 API의 assertion 라이브러리<br>• 가독성 높은 테스트 코드 작성 | ✅ 필수 |
-| **JaCoCo** | 0.8.12 | • 테스트 커버리지 측정<br>• 코드 품질 관리 | 🧪 품질향상 |
-| **Spring Boot Test** | 3.2.0 | • 통합 테스트 프레임워크<br>• Mock 기반 테스트 | ✅ 필수 |
-| **TestContainers** | 1.19.3 | • 격리된 테스트 환경<br>• 실제 DB와 유사한 테스트 | 🧪 품질향상 |
-| **Rest Assured** | 5.3.2 | • API 테스트<br>• End-to-End 테스트 | 🧪 품질향상 |
+        // When & Then
+        mockMvc.perform(post("/api/surveys")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andDo(print())
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.error").value("VALIDATION_FAILED"));
+    }
 
-##  향후 확장을 위한 제거된 라이브러리 적용 방법
+    @Test
+    @DisplayName("질문 개수가 10개를 초과하는 설문조사 생성 요청 시 400 Bad Request 응답")
+    void 질문_개수_초과_설문조사_생성_요청_실패() throws Exception {
+        // Given - 11개의 질문 생성
+        List<CreateQuestionRequest> questions = List.of(
+                new CreateQuestionRequest("질문1", null, QuestionType.SHORT_TEXT, false, null),
+                new CreateQuestionRequest("질문2", null, QuestionType.SHORT_TEXT, false, null),
+                new CreateQuestionRequest("질문3", null, QuestionType.SHORT_TEXT, false, null),
+                new CreateQuestionRequest("질문4", null, QuestionType.SHORT_TEXT, false, null),
+                new CreateQuestionRequest("질문5", null, QuestionType.SHORT_TEXT, false, null),
+                new CreateQuestionRequest("질문6", null, QuestionType.SHORT_TEXT, false, null),
+                new CreateQuestionRequest("질문7", null, QuestionType.SHORT_TEXT, false, null),
+                new CreateQuestionRequest("질문8", null, QuestionType.SHORT_TEXT, false, null),
+                new CreateQuestionRequest("질문9", null, QuestionType.SHORT_TEXT, false, null),
+                new CreateQuestionRequest("질문10", null, QuestionType.SHORT_TEXT, false, null),
+                new CreateQuestionRequest("질문11", null, QuestionType.SHORT_TEXT, false, null)
+        );
 
-### **운영 환경 데이터베이스 (PostgreSQL)**
-```groovy
-// survey-infrastructure/build.gradle.kts
-dependencies {
-    runtimeOnly("org.postgresql:postgresql")
-    implementation("org.flywaydb:flyway-core")
-    implementation("org.flywaydb:flyway-database-postgresql")
+        CreateSurveyRequest request = new CreateSurveyRequest(
+                "설문조사 제목",
+                "설문조사 설명",
+                questions
+        );
+
+        // When & Then
+        mockMvc.perform(post("/api/surveys")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andDo(print())
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.error").value("VALIDATION_FAILED"));
+    }
+
+    @Test
+    @DisplayName("선택형 질문에 옵션이 없는 설문조사 생성 요청 시 잘못된 요청으로 처리")
+    void 선택형_질문_옵션_없는_요청_실패() throws Exception {
+        // Given
+        CreateSurveyRequest request = new CreateSurveyRequest(
+                "설문조사 제목",
+                "설문조사 설명",
+                List.of(
+                        new CreateQuestionRequest(
+                                "선택 질문",
+                                "선택해주세요",
+                                QuestionType.SINGLE_CHOICE,
+                                true,
+                                null // 선택형 질문인데 옵션이 없음
+                        )
+                )
+        );
+
+        // When & Then
+        mockMvc.perform(post("/api/surveys")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andDo(print())
+                .andExpect(status().isBadRequest());
+    }
 }
-```
-
-**적용 시점**: 운영 배포 시
-**적용 이유**: 
-- H2는 개발/테스트용, PostgreSQL은 운영환경 안정성
-- Flyway로 스키마 버전 관리 및 마이그레이션 자동화
-
-### **분산 캐싱 및 세션 관리 (Redis)**
-```groovy
-// survey-infrastructure/build.gradle.kts
-dependencies {
-    implementation("org.springframework.boot:spring-boot-starter-data-redis")
-    implementation("org.redisson:redisson-spring-boot-starter:3.25.2")
-    implementation("org.springframework.session:spring-session-data-redis")
-}
-```
-
-**적용 시점**: 다중 인스턴스 배포 시
-**적용 이유**: 
-- 세션 외부화로 로드밸런서 환경 지원
-- Redisson으로 분산 락 구현 (동시성 이슈 해결)
-- 응답 집계 결과 캐싱으로 성능 향상
-
-### **분산 추적 및 모니터링 (Zipkin)**
-```groovy
-// survey-api/build.gradle.kts
-dependencies {
-    implementation("io.micrometer:micrometer-tracing-bridge-brave")
-    implementation("io.zipkin.reporter2:zipkin-reporter-brave")
-    implementation("io.micrometer:micrometer-registry-prometheus")
-}
-```
-
-**적용 시점**: 마이크로서비스 분리 시
-**적용 이유**: 
-- 서비스 간 요청 흐름 추적
-- 성능 병목 지점 분석
-- Prometheus + Grafana 연동
-
-### **복원력 패턴 (Resilience4j)**
-```groovy
-// survey-api/build.gradle.kts
-dependencies {
-    implementation("io.github.resilience4j:resilience4j-spring-boot3:2.2.0")
-    implementation("io.github.resilience4j:resilience4j-reactor:2.2.0")
-}
-```
-
-**적용 시점**: 외부 API 연동 시 (이메일, SMS 등)
-**적용 이유**: 
-- Circuit Breaker로 장애 전파 방지
-- Retry 패턴으로 일시적 장애 극복
-- Bulkhead로 자원 격리
-
-### **Rate Limiting (Bucket4j)**
-```groovy
-// survey-api/build.gradle.kts
-dependencies {
-    implementation("com.github.vladimir-bukhtoyarov:bucket4j-core:7.6.0")
-    implementation("com.github.vladimir-bukhtoyarov:bucket4j-redis:7.6.0")
-}
-```
-
-**적용 시점**: 공개 API 제공 시
-**적용 이유**: 
-- API 남용 방지
-- 사용자별/IP별 요청 제한
-- DDoS 공격 대응
-
-
-## 🔒 데이터 일관성 보장 전략
-
-### **설문 수정 시 기존 응답 보존 - 3중 보호 메커니즘**
-
-**핵심 문제**: 설문조사가 수정될 때 기존 응답의 맥락이 변경되는 문제
-- 질문 제목이 바뀌면 응답이 엉뚱한 질문에 대한 답이 됨
-- 선택지가 변경되면 기존 선택한 답변이 사라짐  
-- 질문이 삭제되면 해당 답변도 의미를 잃음
-
-**해결책**: 완벽한 3중 보호 전략으로 데이터 무결성 100% 보장
-
-#### **1️⃣ 엔티티 레벨 버전 관리 (`BaseEntity`)**
-```java
-@Version
-@Column(name = "version")
-private Long version = 0L;
-```
-- JPA 낙관적 락으로 동시성 제어
-- 설문 수정 시마다 버전 자동 증가
-- 변경 이력 추적 기반 제공
-
-#### **2️⃣ 질문 레벨 Soft Delete (`SurveyQuestion`)**
-```java
-@Column(name = "active", nullable = false)
-private boolean active = true;
-
-public void deactivate() {
-    this.active = false;  // 물리적 삭제 대신 비활성화
-}
-```
-- 질문 수정/삭제 시 기존 질문은 비활성화만 처리
-- 기존 응답이 참조하는 질문 정보 영구 보존
-- `getActiveQuestions()`로 현재 유효한 질문만 조회
-
-#### **3️⃣ 응답 레벨 완전한 스냅샷 (`SurveyAnswer`)**
-```java
-// 기본 스냅샷
-@Column(name = "question_title", nullable = false)
-private String questionTitle;
-
-@Column(name = "question_type", nullable = false)
-private QuestionType questionType;
-
-// 완전한 질문 정보 스냅샷 (JSON)
-@Column(name = "question_snapshot", columnDefinition = "TEXT")
-private String questionSnapshot;
-
-// 선택지 스냅샷 (선택형 질문용)
-@ElementCollection
-@CollectionTable(name = "answer_choice_snapshots")
-private List<String> availableChoicesSnapshot;
-```
-
-**🎯 보장되는 효과:**
-- **영구 보존**: 설문이 아무리 변경되어도 기존 응답의 의미 보존
-- **완전한 맥락**: 응답 시점의 질문 제목, 설명, 선택지 모두 보존
-- **호환성 체크**: `isStillValidAgainstCurrentChoices()`로 현재 설문과의 호환성 확인
-- **무손실 마이그레이션**: 설문 구조가 완전히 바뀌어도 기존 데이터 손실 없음
-
-### **실제 사용 시나리오**
-```java
-// 📊 2023년 만족도 조사 응답: "매우 만족" 선택
-// 🔄 2024년 설문 수정: "매우 만족" 옵션 제거, "탁월함" 추가
-// ✅ 결과: 2023년 응답은 여전히 "매우 만족"으로 의미 보존
-// ✅ 새 응답: "탁월함" 옵션 사용 가능
-
-SurveyAnswer answer = response.getAnswerByQuestionId(questionId);
-answer.getOriginalChoices();  // ["불만족", "보통", "만족", "매우 만족"]
-answer.getSingleAnswer();     // "매우 만족" (영구 보존)
-```
-
-### **🔍 향후 이벤트 소싱 확장 준비**
-
-현재 구현에는 설문조사 변경 이력을 추적하는 `SurveyEvent` 엔티티가 포함되어 있어, 향후 완전한 이벤트 소싱 패턴으로 확장 가능합니다.
-
-```java
-// 설문 생성 이벤트
-new SurveyEvent(surveyId, SurveyEventType.SURVEY_CREATED, eventData, "admin@company.com");
-
-// 질문 수정 이벤트  
-new SurveyEvent(surveyId, SurveyEventType.QUESTION_UPDATED, eventData, "editor@company.com");
-
-// 응답 제출 이벤트
-new SurveyEvent(surveyId, SurveyEventType.RESPONSE_SUBMITTED, eventData, "respondent");
-```
-
-## 🚀 실행 방법
-
-### **개발 환경 실행**
-```bash
-# 프로젝트 빌드
-./gradlew build
-
-# 애플리케이션 실행
-./gradlew :survey-api:bootRun
-```
-
-### **접속 정보**
-- **애플리케이션**: http://localhost:8080
-- **Swagger UI**: http://localhost:8080/swagger-ui.html
-- **H2 Console**: http://localhost:8080/h2-console
-- **Health Check**: http://localhost:8080/actuator/health
-
-## 📝 API 명세
-
-### **주요 엔드포인트**
-| Method | Endpoint | 설명 |
-|--------|----------|------|
-| `POST` | `/api/surveys` | 설문조사 생성 |
-| `PUT` | `/api/surveys/{id}` | 설문조사 수정 |
-| `POST` | `/api/surveys/{id}/responses` | 응답 제출 |
-| `GET` | `/api/surveys/{id}/responses` | 응답 조회 |
-| `GET` | `/api/surveys/{id}/responses/search` | 응답 검색 (Advanced) |
-
-*상세한 API 명세는 Swagger UI에서 확인 가능합니다.*
-
-
-## 📊 성능 최적화 전략
-
-### **현재 적용된 최적화**
-- **ULID 기반 ID**: 분산 환경에서 충돌 없는 고유 ID 생성
-- **QueryDSL**: 복잡한 검색 조건의 동적 쿼리 최적화
-- **JPA 최적화**: Lazy Loading, Fetch Join 활용
-
-### **향후 적용 예정 최적화**
-- **데이터베이스 인덱싱**: 검색 컬럼 복합 인덱스
-- **Redis 캐싱**: 설문조사 메타데이터 캐시
-- **Connection Pool 튜닝**: HikariCP 설정 최적화

--- a/project/jooeun-onboarding/survey-api/build.gradle.kts
+++ b/project/jooeun-onboarding/survey-api/build.gradle.kts
@@ -8,10 +8,13 @@ dependencies {
     implementation(project(":survey-common"))
     implementation(project(":survey-domain"))
     implementation(project(":survey-infrastructure"))
-    
+
     // Web & API
     implementation("org.springframework.boot:spring-boot-starter-web")
-    
+
+    //JPA
+    implementation("org.springframework.boot:spring-boot-starter-data-jpa")
+
     // API 문서화 (Swagger/OpenAPI) - API 명세 제출 요구사항
     implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.2.0")
     

--- a/project/jooeun-onboarding/survey-api/src/main/java/com/innercircle/survey/api/controller/SurveyController.java
+++ b/project/jooeun-onboarding/survey-api/src/main/java/com/innercircle/survey/api/controller/SurveyController.java
@@ -88,31 +88,7 @@ public class SurveyController {
                     required = true,
                     content = @Content(
                             mediaType = "application/json",
-                            schema = @Schema(implementation = CreateSurveyRequest.class),
-                            examples = @ExampleObject(
-                                    name = "고객 만족도 조사 예시",
-                                    value = """
-                                    {
-                                        "title": "2024년 고객 만족도 조사",
-                                        "description": "고객 서비스 개선을 위한 만족도 조사입니다.",
-                                        "questions": [
-                                            {
-                                                "title": "전반적인 서비스에 만족하십니까?",
-                                                "description": "서비스 전반에 대한 만족도를 평가해 주세요.",
-                                                "questionType": "SINGLE_CHOICE",
-                                                "required": true,
-                                                "options": ["매우 불만족", "불만족", "보통", "만족", "매우 만족"]
-                                            },
-                                            {
-                                                "title": "개선사항이나 의견을 자유롭게 작성해 주세요.",
-                                                "description": "더 나은 서비스를 위한 소중한 의견을 들려주세요.",
-                                                "questionType": "LONG_TEXT",
-                                                "required": false
-                                            }
-                                        ]
-                                    }
-                                    """
-                            )
+                            schema = @Schema(implementation = CreateSurveyRequest.class)
                     )
             )
             @Valid @RequestBody CreateSurveyRequest request) {

--- a/project/jooeun-onboarding/survey-api/src/main/java/com/innercircle/survey/api/controller/SurveyController.java
+++ b/project/jooeun-onboarding/survey-api/src/main/java/com/innercircle/survey/api/controller/SurveyController.java
@@ -1,0 +1,222 @@
+package com.innercircle.survey.api.controller;
+
+import com.innercircle.survey.api.dto.request.CreateSurveyRequest;
+import com.innercircle.survey.api.dto.response.SurveyResponse;
+import com.innercircle.survey.api.service.SurveyService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+/**
+ * 설문조사 REST API 컨트롤러
+ * 
+ * 설문조사 생성, 조회, 수정 기능을 제공합니다.
+ */
+@Slf4j
+@RestController
+@RequestMapping("/api/surveys")
+@RequiredArgsConstructor
+@Tag(name = "설문조사 API", description = "설문조사 생성, 조회, 수정 기능을 제공합니다.")
+public class SurveyController {
+
+    private final SurveyService surveyService;
+
+    /**
+     * 설문조사 생성 API
+     */
+    @Operation(
+            summary = "설문조사 생성",
+            description = "새로운 설문조사를 생성합니다. 1~10개의 설문 항목을 포함할 수 있습니다."
+    )
+    @ApiResponses({
+            @ApiResponse(
+                    responseCode = "201",
+                    description = "설문조사 생성 성공",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = SurveyResponse.class)
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "400",
+                    description = "잘못된 요청 데이터",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(
+                                    value = """
+                                    {
+                                        "error": "INVALID_REQUEST",
+                                        "message": "설문조사 제목은 필수입니다.",
+                                        "timestamp": "2024-01-15T10:30:00"
+                                    }
+                                    """
+                            )
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "500",
+                    description = "서버 내부 오류",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(
+                                    value = """
+                                    {
+                                        "error": "INTERNAL_SERVER_ERROR",
+                                        "message": "설문조사 생성에 실패했습니다.",
+                                        "timestamp": "2024-01-15T10:30:00"
+                                    }
+                                    """
+                            )
+                    )
+            )
+    })
+    @PostMapping
+    public ResponseEntity<SurveyResponse> createSurvey(
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                    description = "설문조사 생성 요청 데이터",
+                    required = true,
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = CreateSurveyRequest.class),
+                            examples = @ExampleObject(
+                                    name = "고객 만족도 조사 예시",
+                                    value = """
+                                    {
+                                        "title": "2024년 고객 만족도 조사",
+                                        "description": "고객 서비스 개선을 위한 만족도 조사입니다.",
+                                        "questions": [
+                                            {
+                                                "title": "전반적인 서비스에 만족하십니까?",
+                                                "description": "서비스 전반에 대한 만족도를 평가해 주세요.",
+                                                "questionType": "SINGLE_CHOICE",
+                                                "required": true,
+                                                "options": ["매우 불만족", "불만족", "보통", "만족", "매우 만족"]
+                                            },
+                                            {
+                                                "title": "개선사항이나 의견을 자유롭게 작성해 주세요.",
+                                                "description": "더 나은 서비스를 위한 소중한 의견을 들려주세요.",
+                                                "questionType": "LONG_TEXT",
+                                                "required": false
+                                            }
+                                        ]
+                                    }
+                                    """
+                            )
+                    )
+            )
+            @Valid @RequestBody CreateSurveyRequest request) {
+        
+        log.info("설문조사 생성 요청 - 제목: {}", request.getTitle());
+        
+        SurveyResponse response = surveyService.createSurvey(request);
+        
+        return ResponseEntity.status(HttpStatus.CREATED).body(response);
+    }
+
+    /**
+     * 설문조사 조회 API
+     */
+    @Operation(
+            summary = "설문조사 조회",
+            description = "설문조사 ID로 설문조사 정보를 조회합니다."
+    )
+    @ApiResponses({
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "설문조사 조회 성공",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = SurveyResponse.class)
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "404",
+                    description = "설문조사를 찾을 수 없음",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(
+                                    value = """
+                                    {
+                                        "error": "SURVEY_NOT_FOUND",
+                                        "message": "설문조사를 찾을 수 없습니다: 01HK123ABC456DEF789GHI012J",
+                                        "timestamp": "2024-01-15T10:30:00"
+                                    }
+                                    """
+                            )
+                    )
+            )
+    })
+    @GetMapping("/{surveyId}")
+    public ResponseEntity<SurveyResponse> getSurvey(
+            @Parameter(description = "설문조사 ID", example = "01HK123ABC456DEF789GHI012J")
+            @PathVariable String surveyId) {
+        
+        log.info("설문조사 조회 요청 - ID: {}", surveyId);
+        
+        SurveyResponse response = surveyService.getSurvey(surveyId);
+        
+        return ResponseEntity.ok(response);
+    }
+
+    /**
+     * 설문조사 존재 여부 확인 API
+     */
+    @Operation(
+            summary = "설문조사 존재 확인",
+            description = "설문조사 ID로 설문조사 존재 여부를 확인합니다."
+    )
+    @ApiResponses({
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "존재 확인 성공",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = {
+                                    @ExampleObject(
+                                            name = "존재하는 경우",
+                                            value = """
+                                            {
+                                                "exists": true,
+                                                "surveyId": "01HK123ABC456DEF789GHI012J"
+                                            }
+                                            """
+                                    ),
+                                    @ExampleObject(
+                                            name = "존재하지 않는 경우",
+                                            value = """
+                                            {
+                                                "exists": false,
+                                                "surveyId": "01HK123ABC456DEF789GHI012J"
+                                            }
+                                            """
+                                    )
+                            }
+                    )
+            )
+    })
+    @GetMapping("/{surveyId}/exists")
+    public ResponseEntity<Object> checkSurveyExists(
+            @Parameter(description = "설문조사 ID", example = "01HK123ABC456DEF789GHI012J")
+            @PathVariable String surveyId) {
+        
+        log.info("설문조사 존재 확인 요청 - ID: {}", surveyId);
+        
+        boolean exists = surveyService.existsSurvey(surveyId);
+        
+        return ResponseEntity.ok(java.util.Map.of(
+                "exists", exists,
+                "surveyId", surveyId
+        ));
+    }
+}

--- a/project/jooeun-onboarding/survey-api/src/main/java/com/innercircle/survey/api/dto/request/CreateQuestionRequest.java
+++ b/project/jooeun-onboarding/survey-api/src/main/java/com/innercircle/survey/api/dto/request/CreateQuestionRequest.java
@@ -1,0 +1,95 @@
+package com.innercircle.survey.api.dto.request;
+
+import com.innercircle.survey.common.constants.SurveyConstants;
+import com.innercircle.survey.common.domain.QuestionType;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+/**
+ * 설문 항목 생성 요청 DTO
+ */
+@Schema(description = "설문 항목 생성 요청")
+@Getter
+@NoArgsConstructor
+public class CreateQuestionRequest {
+
+    @Schema(description = "항목 제목", example = "전반적인 서비스에 만족하십니까?")
+    @NotBlank(message = "설문 항목 제목은 필수입니다.")
+    @Size(min = SurveyConstants.Question.MIN_TITLE_LENGTH,
+          max = SurveyConstants.Question.MAX_TITLE_LENGTH,
+          message = "설문 항목 제목은 {min}자 이상 {max}자 이하여야 합니다.")
+    private String title;
+
+    @Schema(description = "항목 설명", example = "서비스 전반에 대한 만족도를 평가해 주세요.")
+    @Size(max = SurveyConstants.Question.MAX_DESCRIPTION_LENGTH,
+          message = "설문 항목 설명은 {max}자 이하여야 합니다.")
+    private String description;
+
+    @Schema(description = "항목 입력 형태", example = "SINGLE_CHOICE")
+    @NotNull(message = "설문 항목 입력 형태는 필수입니다.")
+    private QuestionType questionType;
+
+    @Schema(description = "필수 여부", example = "true")
+    private boolean required = false;
+
+    @Schema(description = "선택 옵션 (선택형 질문만)", 
+            example = "[\"매우 불만족\", \"불만족\", \"보통\", \"만족\", \"매우 만족\"]")
+    private List<String> options;
+
+    /**
+     * 생성자
+     */
+    public CreateQuestionRequest(String title, String description, QuestionType questionType, 
+                               boolean required, List<String> options) {
+        this.title = title;
+        this.description = description;
+        this.questionType = questionType;
+        this.required = required;
+        this.options = options;
+    }
+
+    /**
+     * 선택형 질문 여부 확인
+     */
+    public boolean isChoiceType() {
+        return questionType != null && questionType.isChoiceType();
+    }
+
+    /**
+     * 옵션 검증
+     */
+    public void validateOptions() {
+        if (questionType == null) {
+            return;
+        }
+
+        if (questionType.isChoiceType()) {
+            if (options == null || options.isEmpty()) {
+                throw new IllegalArgumentException("선택형 질문에는 최소 1개의 옵션이 필요합니다.");
+            }
+            
+            if (options.size() > SurveyConstants.Question.MAX_OPTIONS_COUNT) {
+                throw new IllegalArgumentException("선택 옵션은 최대 " + SurveyConstants.Question.MAX_OPTIONS_COUNT + "개까지 가능합니다.");
+            }
+            
+            for (String option : options) {
+                if (option == null || option.trim().isEmpty()) {
+                    throw new IllegalArgumentException("선택 옵션은 빈 값일 수 없습니다.");
+                }
+                if (option.length() > SurveyConstants.Question.MAX_OPTION_LENGTH) {
+                    throw new IllegalArgumentException("선택 옵션은 " + SurveyConstants.Question.MAX_OPTION_LENGTH + "자 이하여야 합니다.");
+                }
+            }
+        } else {
+            if (options != null && !options.isEmpty()) {
+                throw new IllegalArgumentException("텍스트 입력형 질문에는 선택 옵션을 설정할 수 없습니다.");
+            }
+        }
+    }
+}

--- a/project/jooeun-onboarding/survey-api/src/main/java/com/innercircle/survey/api/dto/request/CreateSurveyRequest.java
+++ b/project/jooeun-onboarding/survey-api/src/main/java/com/innercircle/survey/api/dto/request/CreateSurveyRequest.java
@@ -1,0 +1,50 @@
+package com.innercircle.survey.api.dto.request;
+
+import com.innercircle.survey.common.constants.SurveyConstants;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+/**
+ * 설문조사 생성 요청 DTO
+ */
+@Schema(description = "설문조사 생성 요청")
+@Getter
+@NoArgsConstructor
+public class CreateSurveyRequest {
+
+    @Schema(description = "설문조사 제목", example = "2024년 고객 만족도 조사")
+    @NotBlank(message = "설문조사 제목은 필수입니다.")
+    @Size(min = SurveyConstants.Survey.MIN_TITLE_LENGTH, 
+          max = SurveyConstants.Survey.MAX_TITLE_LENGTH,
+          message = "설문조사 제목은 {min}자 이상 {max}자 이하여야 합니다.")
+    private String title;
+
+    @Schema(description = "설문조사 설명", example = "고객 서비스 개선을 위한 만족도 조사입니다.")
+    @Size(max = SurveyConstants.Survey.MAX_DESCRIPTION_LENGTH,
+          message = "설문조사 설명은 {max}자 이하여야 합니다.")
+    private String description;
+
+    @Schema(description = "설문 항목 목록")
+    @NotNull(message = "설문 항목은 필수입니다.")
+    @Size(min = SurveyConstants.Survey.MIN_QUESTIONS_COUNT, 
+          max = SurveyConstants.Survey.MAX_QUESTIONS_COUNT,
+          message = "설문 항목은 {min}개 이상 {max}개 이하여야 합니다.")
+    @Valid
+    private List<CreateQuestionRequest> questions;
+
+    /**
+     * 생성자
+     */
+    public CreateSurveyRequest(String title, String description, List<CreateQuestionRequest> questions) {
+        this.title = title;
+        this.description = description;
+        this.questions = questions;
+    }
+}

--- a/project/jooeun-onboarding/survey-api/src/main/java/com/innercircle/survey/api/dto/response/QuestionResponse.java
+++ b/project/jooeun-onboarding/survey-api/src/main/java/com/innercircle/survey/api/dto/response/QuestionResponse.java
@@ -1,0 +1,52 @@
+package com.innercircle.survey.api.dto.response;
+
+import com.innercircle.survey.common.domain.QuestionType;
+import com.innercircle.survey.domain.survey.SurveyQuestion;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+
+import java.util.List;
+
+/**
+ * 설문 항목 응답 DTO
+ */
+@Schema(description = "설문 항목 응답")
+@Getter
+public class QuestionResponse {
+
+    @Schema(description = "항목 ID", example = "01HK123ABC456DEF789GHI012K")
+    private final String id;
+
+    @Schema(description = "항목 제목", example = "전반적인 서비스에 만족하십니까?")
+    private final String title;
+
+    @Schema(description = "항목 설명", example = "서비스 전반에 대한 만족도를 평가해 주세요.")
+    private final String description;
+
+    @Schema(description = "항목 입력 형태", example = "SINGLE_CHOICE")
+    private final QuestionType questionType;
+
+    @Schema(description = "필수 여부", example = "true")
+    private final boolean required;
+
+    @Schema(description = "표시 순서", example = "1")
+    private final int displayOrder;
+
+    @Schema(description = "선택 옵션 (선택형 질문만)", 
+            example = "[\"매우 불만족\", \"불만족\", \"보통\", \"만족\", \"매우 만족\"]")
+    private final List<String> options;
+
+    /**
+     * 도메인 엔티티로부터 응답 DTO 생성
+     */
+    public QuestionResponse(SurveyQuestion question) {
+        this.id = question.getId();
+        this.title = question.getTitle();
+        this.description = question.getDescription();
+        this.questionType = question.getQuestionType();
+        this.required = question.isRequired();
+        this.displayOrder = question.getDisplayOrder();
+        this.options = question.getQuestionType().isChoiceType() ? 
+                      List.copyOf(question.getOptions()) : null;
+    }
+}

--- a/project/jooeun-onboarding/survey-api/src/main/java/com/innercircle/survey/api/dto/response/SurveyResponse.java
+++ b/project/jooeun-onboarding/survey-api/src/main/java/com/innercircle/survey/api/dto/response/SurveyResponse.java
@@ -1,0 +1,69 @@
+package com.innercircle.survey.api.dto.response;
+
+import com.innercircle.survey.domain.survey.Survey;
+import com.innercircle.survey.domain.survey.SurveyQuestion;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+/**
+ * 설문조사 응답 DTO
+ */
+@Schema(description = "설문조사 응답")
+@Getter
+public class SurveyResponse {
+
+    @Schema(description = "설문조사 ID", example = "01HK123ABC456DEF789GHI012J")
+    private final String id;
+
+    @Schema(description = "설문조사 제목", example = "2024년 고객 만족도 조사")
+    private final String title;
+
+    @Schema(description = "설문조사 설명", example = "고객 서비스 개선을 위한 만족도 조사입니다.")
+    private final String description;
+
+    @Schema(description = "설문 항목 목록")
+    private final List<QuestionResponse> questions;
+
+    @Schema(description = "생성 일시", example = "2024-01-15T10:30:00")
+    private final LocalDateTime createdAt;
+
+    @Schema(description = "수정 일시", example = "2024-01-15T14:20:00")
+    private final LocalDateTime updatedAt;
+
+    @Schema(description = "버전", example = "1")
+    private final Long version;
+
+    /**
+     * 도메인 엔티티로부터 응답 DTO 생성
+     */
+    public SurveyResponse(Survey survey) {
+        this.id = survey.getId();
+        this.title = survey.getTitle();
+        this.description = survey.getDescription();
+        this.questions = survey.getActiveQuestions().stream()
+                .map(QuestionResponse::new)
+                .toList();
+        this.createdAt = survey.getCreatedAt();
+        this.updatedAt = survey.getUpdatedAt();
+        this.version = survey.getVersion();
+    }
+
+    /**
+     * 활성 질문만으로 응답 DTO 생성
+     */
+    public static SurveyResponse fromSurveyWithActiveQuestions(Survey survey) {
+        return new SurveyResponse(survey);
+    }
+
+    /**
+     * 모든 질문으로 응답 DTO 생성 (관리용)
+     */
+    public static SurveyResponse fromSurveyWithAllQuestions(Survey survey, List<SurveyQuestion> allQuestions) {
+        SurveyResponse response = new SurveyResponse(survey);
+        // 필요시 구현 - 현재는 활성 질문만 반환
+        return response;
+    }
+}

--- a/project/jooeun-onboarding/survey-api/src/main/java/com/innercircle/survey/api/exception/ErrorResponse.java
+++ b/project/jooeun-onboarding/survey-api/src/main/java/com/innercircle/survey/api/exception/ErrorResponse.java
@@ -1,0 +1,33 @@
+package com.innercircle.survey.api.exception;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+import java.util.Map;
+
+/**
+ * 에러 응답 DTO
+ * 
+ * API 에러 발생 시 일관된 형태의 응답을 제공합니다.
+ */
+@Schema(description = "에러 응답")
+@Getter
+@Builder(toBuilder = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class ErrorResponse {
+
+    @Schema(description = "에러 코드", example = "VALIDATION_FAILED")
+    private final String error;
+
+    @Schema(description = "에러 메시지", example = "입력 데이터 검증에 실패했습니다.")
+    private final String message;
+
+    @Schema(description = "상세 에러 정보")
+    private final Map<String, String> details;
+
+    @Schema(description = "에러 발생 시각", example = "2024-01-15T10:30:00")
+    private final LocalDateTime timestamp;
+}

--- a/project/jooeun-onboarding/survey-api/src/main/java/com/innercircle/survey/api/exception/GlobalExceptionHandler.java
+++ b/project/jooeun-onboarding/survey-api/src/main/java/com/innercircle/survey/api/exception/GlobalExceptionHandler.java
@@ -1,0 +1,103 @@
+package com.innercircle.survey.api.exception;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import java.time.LocalDateTime;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * 전역 예외 처리기
+ * 
+ * 애플리케이션에서 발생하는 예외를 일관된 형태로 처리합니다.
+ */
+@Slf4j
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    /**
+     * Bean Validation 예외 처리
+     */
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ErrorResponse> handleValidationException(MethodArgumentNotValidException ex) {
+        log.warn("Validation 예외 발생: {}", ex.getMessage());
+        
+        Map<String, String> errors = new HashMap<>();
+        ex.getBindingResult().getAllErrors().forEach((error) -> {
+            String fieldName = ((FieldError) error).getField();
+            String errorMessage = error.getDefaultMessage();
+            errors.put(fieldName, errorMessage);
+        });
+        
+        ErrorResponse errorResponse = ErrorResponse.builder()
+                .error("VALIDATION_FAILED")
+                .message("입력 데이터 검증에 실패했습니다.")
+                .details(errors)
+                .timestamp(LocalDateTime.now())
+                .build();
+        
+        return ResponseEntity.badRequest().body(errorResponse);
+    }
+
+    /**
+     * IllegalArgumentException 처리
+     */
+    @ExceptionHandler(IllegalArgumentException.class)
+    public ResponseEntity<ErrorResponse> handleIllegalArgumentException(IllegalArgumentException ex) {
+        log.warn("잘못된 인수 예외: {}", ex.getMessage());
+        
+        ErrorResponse errorResponse = ErrorResponse.builder()
+                .error("INVALID_ARGUMENT")
+                .message(ex.getMessage())
+                .timestamp(LocalDateTime.now())
+                .build();
+        
+        // 설문조사를 찾을 수 없는 경우 404 반환
+        if (ex.getMessage().contains("설문조사를 찾을 수 없습니다")) {
+            errorResponse = errorResponse.toBuilder()
+                    .error("SURVEY_NOT_FOUND")
+                    .build();
+            return ResponseEntity.status(HttpStatus.NOT_FOUND).body(errorResponse);
+        }
+        
+        return ResponseEntity.badRequest().body(errorResponse);
+    }
+
+    /**
+     * RuntimeException 처리
+     */
+    @ExceptionHandler(RuntimeException.class)
+    public ResponseEntity<ErrorResponse> handleRuntimeException(RuntimeException ex) {
+        log.error("런타임 예외: {}", ex.getMessage(), ex);
+        
+        ErrorResponse errorResponse = ErrorResponse.builder()
+                .error("INTERNAL_SERVER_ERROR")
+                .message("서버 내부 오류가 발생했습니다.")
+                .timestamp(LocalDateTime.now())
+                .build();
+        
+        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(errorResponse);
+    }
+
+    /**
+     * 기타 모든 예외 처리
+     */
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ErrorResponse> handleException(Exception ex) {
+        log.error("예상치 못한 예외: {}", ex.getMessage(), ex);
+        
+        ErrorResponse errorResponse = ErrorResponse.builder()
+                .error("INTERNAL_SERVER_ERROR")
+                .message("예상치 못한 오류가 발생했습니다.")
+                .timestamp(LocalDateTime.now())
+                .build();
+        
+        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(errorResponse);
+    }
+}

--- a/project/jooeun-onboarding/survey-api/src/main/java/com/innercircle/survey/api/service/SurveyService.java
+++ b/project/jooeun-onboarding/survey-api/src/main/java/com/innercircle/survey/api/service/SurveyService.java
@@ -35,28 +35,24 @@ public class SurveyService {
     @Transactional
     public SurveyResponse createSurvey(CreateSurveyRequest request) {
         log.info("설문조사 생성 시작 - 제목: {}, 질문 수: {}", request.getTitle(), request.getQuestions().size());
-        
-        try {
-            // 1. 설문조사 기본 정보 생성
-            Survey survey = new Survey(request.getTitle(), request.getDescription());
-            
-            // 2. 설문 항목들 생성 및 추가
-            List<SurveyQuestion> questions = createQuestions(request.getQuestions());
-            for (SurveyQuestion question : questions) {
-                survey.addQuestion(question);
-            }
-            
-            // 3. 설문조사 저장
-            Survey savedSurvey = surveyRepository.save(survey);
-            
-            log.info("설문조사 생성 완료 - ID: {}, 제목: {}", savedSurvey.getId(), savedSurvey.getTitle());
-            
-            return new SurveyResponse(savedSurvey);
-            
-        } catch (Exception e) {
-            log.error("설문조사 생성 실패 - 제목: {}, 오류: {}", request.getTitle(), e.getMessage(), e);
-            throw new RuntimeException("설문조사 생성에 실패했습니다: " + e.getMessage(), e);
+
+        // 1. 설문조사 기본 정보 생성
+        Survey survey = new Survey(request.getTitle(), request.getDescription());
+
+        // 2. 설문 항목들 생성 및 추가
+        List<SurveyQuestion> questions = createQuestions(request.getQuestions());
+        for (SurveyQuestion question : questions) {
+            survey.addQuestion(question);
         }
+
+        // 3. 설문조사 저장
+        Survey savedSurvey = surveyRepository.save(survey);
+
+        log.info("설문조사 생성 완료 - ID: {}, 제목: {}", savedSurvey.getId(), savedSurvey.getTitle());
+
+        return new SurveyResponse(savedSurvey);
+            
+
     }
 
     /**

--- a/project/jooeun-onboarding/survey-api/src/main/java/com/innercircle/survey/api/service/SurveyService.java
+++ b/project/jooeun-onboarding/survey-api/src/main/java/com/innercircle/survey/api/service/SurveyService.java
@@ -1,0 +1,120 @@
+package com.innercircle.survey.api.service;
+
+import com.innercircle.survey.api.dto.request.CreateQuestionRequest;
+import com.innercircle.survey.api.dto.request.CreateSurveyRequest;
+import com.innercircle.survey.api.dto.response.SurveyResponse;
+import com.innercircle.survey.domain.survey.Survey;
+import com.innercircle.survey.domain.survey.SurveyQuestion;
+import com.innercircle.survey.infrastructure.repository.SurveyRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+/**
+ * 설문조사 서비스
+ * 
+ * 설문조사 관련 비즈니스 로직을 처리합니다.
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class SurveyService {
+
+    private final SurveyRepository surveyRepository;
+
+    /**
+     * 설문조사 생성
+     *
+     * @param request 설문조사 생성 요청
+     * @return 생성된 설문조사
+     */
+    @Transactional
+    public SurveyResponse createSurvey(CreateSurveyRequest request) {
+        log.info("설문조사 생성 시작 - 제목: {}, 질문 수: {}", request.getTitle(), request.getQuestions().size());
+        
+        try {
+            // 1. 설문조사 기본 정보 생성
+            Survey survey = new Survey(request.getTitle(), request.getDescription());
+            
+            // 2. 설문 항목들 생성 및 추가
+            List<SurveyQuestion> questions = createQuestions(request.getQuestions());
+            for (SurveyQuestion question : questions) {
+                survey.addQuestion(question);
+            }
+            
+            // 3. 설문조사 저장
+            Survey savedSurvey = surveyRepository.save(survey);
+            
+            log.info("설문조사 생성 완료 - ID: {}, 제목: {}", savedSurvey.getId(), savedSurvey.getTitle());
+            
+            return new SurveyResponse(savedSurvey);
+            
+        } catch (Exception e) {
+            log.error("설문조사 생성 실패 - 제목: {}, 오류: {}", request.getTitle(), e.getMessage(), e);
+            throw new RuntimeException("설문조사 생성에 실패했습니다: " + e.getMessage(), e);
+        }
+    }
+
+    /**
+     * 설문조사 ID로 조회
+     *
+     * @param surveyId 설문조사 ID
+     * @return 설문조사
+     */
+    public SurveyResponse getSurvey(String surveyId) {
+        log.info("설문조사 조회 - ID: {}", surveyId);
+        
+        Survey survey = surveyRepository.findByIdWithActiveQuestions(surveyId)
+                .orElseThrow(() -> new IllegalArgumentException("설문조사를 찾을 수 없습니다: " + surveyId));
+        
+        return new SurveyResponse(survey);
+    }
+
+    /**
+     * 설문조사 존재 여부 확인
+     *
+     * @param surveyId 설문조사 ID
+     * @return 존재 여부
+     */
+    public boolean existsSurvey(String surveyId) {
+        return surveyRepository.existsById(surveyId);
+    }
+
+    /**
+     * 요청 DTO로부터 설문 항목들 생성
+     */
+    private List<SurveyQuestion> createQuestions(List<CreateQuestionRequest> questionRequests) {
+        return questionRequests.stream()
+                .map(this::createQuestion)
+                .toList();
+    }
+
+    /**
+     * 개별 설문 항목 생성
+     */
+    private SurveyQuestion createQuestion(CreateQuestionRequest request) {
+        // 선택 옵션 검증
+        request.validateOptions();
+        
+        if (request.getQuestionType().isChoiceType()) {
+            return new SurveyQuestion(
+                    request.getTitle(),
+                    request.getDescription(),
+                    request.getQuestionType(),
+                    request.isRequired(),
+                    request.getOptions()
+            );
+        } else {
+            return new SurveyQuestion(
+                    request.getTitle(),
+                    request.getDescription(),
+                    request.getQuestionType(),
+                    request.isRequired()
+            );
+        }
+    }
+}

--- a/project/jooeun-onboarding/survey-api/src/main/java/com/innercircle/survey/config/JpaConfig.java
+++ b/project/jooeun-onboarding/survey-api/src/main/java/com/innercircle/survey/config/JpaConfig.java
@@ -1,0 +1,17 @@
+package com.innercircle.survey.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
+
+/**
+ * JPA 설정
+ * 
+ * JPA Auditing과 Repository 기본 설정을 담당합니다.
+ */
+@Configuration
+@EnableJpaAuditing
+@EnableJpaRepositories(basePackages = "com.innercircle.survey.infrastructure.repository")
+public class JpaConfig {
+    // JPA Auditing 자동 설정을 활성화하여 BaseEntity의 @CreatedDate, @LastModifiedDate 자동 처리
+}

--- a/project/jooeun-onboarding/survey-api/src/main/resources/application.yml
+++ b/project/jooeun-onboarding/survey-api/src/main/resources/application.yml
@@ -1,3 +1,6 @@
+server:
+  port: 8080
+
 spring:
   profiles:
     active: local
@@ -23,7 +26,6 @@ spring:
         dialect: org.hibernate.dialect.H2Dialect
         
   jackson:
-    property-naming-strategy: SNAKE_CASE
     serialization:
       write-dates-as-timestamps: false
 

--- a/project/jooeun-onboarding/survey-api/src/test/java/com/innercircle/survey/api/integration/SurveyIntegrationTest.java
+++ b/project/jooeun-onboarding/survey-api/src/test/java/com/innercircle/survey/api/integration/SurveyIntegrationTest.java
@@ -1,0 +1,337 @@
+package com.innercircle.survey.api.integration;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.innercircle.survey.api.dto.request.CreateQuestionRequest;
+import com.innercircle.survey.api.dto.request.CreateSurveyRequest;
+import com.innercircle.survey.common.domain.QuestionType;
+import com.innercircle.survey.domain.survey.Survey;
+import com.innercircle.survey.infrastructure.repository.SurveyRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.MethodOrderer.OrderAnnotation;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * 설문조사 통합 테스트
+ * 
+ * 실제 DB와 전체 애플리케이션 컨텍스트를 사용한 End-to-End 테스트
+ */
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@AutoConfigureTestDatabase
+@TestMethodOrder(OrderAnnotation.class)
+@ActiveProfiles("test")
+@Transactional
+@DisplayName("설문조사 통합 테스트")
+class SurveyIntegrationTest {
+
+    @LocalServerPort
+    private int port;
+
+    @Autowired
+    private TestRestTemplate restTemplate;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Autowired
+    private SurveyRepository surveyRepository;
+
+    @Test
+    @DisplayName("설문조사 생성부터 조회까지 전체 플로우 테스트")
+    void 설문조사_생성_조회_전체_플로우() throws Exception {
+        // Given - 설문조사 생성 요청
+        CreateSurveyRequest createRequest = new CreateSurveyRequest(
+                "2024년 직원 만족도 조사",
+                "직장 생활 만족도와 업무 환경 개선을 위한 조사입니다.",
+                List.of(
+                        new CreateQuestionRequest(
+                                "현재 직무에 만족하십니까?",
+                                "전반적인 직무 만족도를 평가해 주세요.",
+                                QuestionType.SINGLE_CHOICE,
+                                true,
+                                List.of("매우 불만족", "불만족", "보통", "만족", "매우 만족")
+                        ),
+                        new CreateQuestionRequest(
+                                "선호하는 근무 형태는?",
+                                "가장 선호하는 근무 방식을 모두 선택해 주세요.",
+                                QuestionType.MULTIPLE_CHOICE,
+                                false,
+                                List.of("재택근무", "출근", "하이브리드", "자율근무")
+                        ),
+                        new CreateQuestionRequest(
+                                "이름을 입력해 주세요.",
+                                null,
+                                QuestionType.SHORT_TEXT,
+                                true,
+                                null
+                        ),
+                        new CreateQuestionRequest(
+                                "개선사항이나 건의사항을 자유롭게 작성해 주세요.",
+                                "더 나은 직장 환경을 위한 의견을 들려주세요.",
+                                QuestionType.LONG_TEXT,
+                                false,
+                                null
+                        )
+                )
+        );
+
+        // When 1 - 설문조사 생성
+        String createUrl = "http://localhost:" + port + "/api/surveys";
+        ResponseEntity<String> createResponse = restTemplate.postForEntity(createUrl, createRequest, String.class);
+        
+        // Then 1 - 생성된 설문조사 확인
+        assertThat(createResponse.getStatusCode()).isEqualTo(HttpStatus.CREATED);
+        assertThat(createResponse.getBody()).isNotNull();
+        
+        var createResponseBody = objectMapper.readTree(createResponse.getBody());
+        String surveyId = createResponseBody.get("id").asText();
+        assertThat(surveyId).isNotEmpty();
+        assertThat(createResponseBody.get("title").asText()).isEqualTo("2024년 직원 만족도 조사");
+        assertThat(createResponseBody.get("description").asText()).isEqualTo("직장 생활 만족도와 업무 환경 개선을 위한 조사입니다.");
+        assertThat(createResponseBody.get("questions")).isNotNull();
+        assertThat(createResponseBody.get("questions")).hasSize(4);
+
+        // DB에서 실제 저장 확인
+        Survey savedSurvey = surveyRepository.findByIdWithActiveQuestions(surveyId).orElse(null);
+        assertThat(savedSurvey).isNotNull();
+        assertThat(savedSurvey.getTitle()).isEqualTo("2024년 직원 만족도 조사");
+        assertThat(savedSurvey.getActiveQuestions()).hasSize(4);
+
+        // When 2 - 설문조사 조회
+        String getUrl = "http://localhost:" + port + "/api/surveys/" + surveyId;
+        ResponseEntity<String> getResponse = restTemplate.getForEntity(getUrl, String.class);
+        
+        // Then 2 - 조회 결과 확인
+        assertThat(getResponse.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(getResponse.getBody()).isNotNull();
+        
+        var getResponseBody = objectMapper.readTree(getResponse.getBody());
+        assertThat(getResponseBody.get("id").asText()).isEqualTo(surveyId);
+        assertThat(getResponseBody.get("title").asText()).isEqualTo("2024년 직원 만족도 조사");
+        assertThat(getResponseBody.get("questions")).hasSize(4);
+
+        // 질문 순서 및 타입 확인
+        var questions = getResponseBody.get("questions");
+        assertThat(questions.get(0).get("questionType").asText()).isEqualTo("SINGLE_CHOICE");
+        assertThat(questions.get(0).get("required").asBoolean()).isTrue();
+        assertThat(questions.get(0).get("displayOrder").asInt()).isEqualTo(1);
+        
+        assertThat(questions.get(1).get("questionType").asText()).isEqualTo("MULTIPLE_CHOICE");
+        assertThat(questions.get(1).get("required").asBoolean()).isFalse();
+        assertThat(questions.get(1).get("displayOrder").asInt()).isEqualTo(2);
+
+        // When 3 - 설문조사 존재 확인
+        String existsUrl = "http://localhost:" + port + "/api/surveys/" + surveyId + "/exists";
+        ResponseEntity<String> existsResponse = restTemplate.getForEntity(existsUrl, String.class);
+        
+        // Then 3 - 존재 확인 결과
+        assertThat(existsResponse.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(existsResponse.getBody()).isNotNull();
+        
+        var existsResponseBody = objectMapper.readTree(existsResponse.getBody());
+        assertThat(existsResponseBody.get("exists").asBoolean()).isTrue();
+        assertThat(existsResponseBody.get("surveyId").asText()).isEqualTo(surveyId);
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 설문조사 조회 시 404 Not Found 응답")
+    void 존재하지_않는_설문조사_조회_실패() throws Exception {
+        // Given
+        String nonExistentSurveyId = "01HK123NONEXISTENT456789";
+
+        // When
+        String getUrl = "http://localhost:" + port + "/api/surveys/" + nonExistentSurveyId;
+        ResponseEntity<String> response = restTemplate.getForEntity(getUrl, String.class);
+        
+        // Then
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
+        assertThat(response.getBody()).isNotNull();
+        
+        var responseBody = objectMapper.readTree(response.getBody());
+        assertThat(responseBody.get("error").asText()).isEqualTo("SURVEY_NOT_FOUND");
+        assertThat(responseBody.get("message").asText()).contains("설문조사를 찾을 수 없습니다");
+        assertThat(responseBody.get("message").asText()).contains(nonExistentSurveyId);
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 설문조사 존재 확인 시 false 응답")
+    void 존재하지_않는_설문조사_존재_확인() {
+        // Given
+        String nonExistentSurveyId = "01HK123NONEXISTENT456789";
+
+        // When
+        String existsUrl = "http://localhost:" + port + "/api/surveys/" + nonExistentSurveyId + "/exists";
+        ResponseEntity<String> response = restTemplate.getForEntity(existsUrl, String.class);
+        
+        // Then
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody()).isNotNull();
+        
+        try {
+            var responseBody = objectMapper.readTree(response.getBody());
+            assertThat(responseBody.get("exists").asBoolean()).isFalse();
+            assertThat(responseBody.get("surveyId").asText()).isEqualTo(nonExistentSurveyId);
+        } catch (Exception e) {
+            throw new RuntimeException("JSON 파싱 실패", e);
+        }
+    }
+
+    @Test
+    @DisplayName("다양한 질문 타입을 포함한 복합 설문조사 생성 및 검증")
+    void 복합_설문조사_생성_검증() throws Exception {
+        // Given - 모든 질문 타입을 포함한 설문조사
+        CreateSurveyRequest request = new CreateSurveyRequest(
+                "종합 피드백 설문조사",
+                "다양한 질문 형태를 통한 종합적인 피드백 수집",
+                List.of(
+                        new CreateQuestionRequest(
+                                "이름",
+                                "성함을 입력해 주세요.",
+                                QuestionType.SHORT_TEXT,
+                                true,
+                                null
+                        ),
+                        new CreateQuestionRequest(
+                                "서비스 만족도",
+                                "전반적인 서비스 만족도를 선택해 주세요.",
+                                QuestionType.SINGLE_CHOICE,
+                                true,
+                                List.of("1점", "2점", "3점", "4점", "5점")
+                        ),
+                        new CreateQuestionRequest(
+                                "관심 분야",
+                                "관심 있는 분야를 모두 선택해 주세요.",
+                                QuestionType.MULTIPLE_CHOICE,
+                                false,
+                                List.of("기술", "디자인", "마케팅", "영업", "경영", "기타")
+                        ),
+                        new CreateQuestionRequest(
+                                "상세 의견",
+                                "서비스에 대한 상세한 의견을 작성해 주세요.",
+                                QuestionType.LONG_TEXT,
+                                false,
+                                null
+                        )
+                )
+        );
+
+        // When
+        String url = "http://localhost:" + port + "/api/surveys";
+        ResponseEntity<String> response = restTemplate.postForEntity(url, request, String.class);
+        
+        // Then
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.CREATED);
+        assertThat(response.getBody()).isNotNull();
+        
+        var responseBody = objectMapper.readTree(response.getBody());
+        String surveyId = responseBody.get("id").asText();
+        assertThat(surveyId).isNotEmpty();
+
+        // DB 검증
+        Survey survey = surveyRepository.findByIdWithActiveQuestions(surveyId).orElse(null);
+        assertThat(survey).isNotNull();
+        assertThat(survey.getActiveQuestions()).hasSize(4);
+
+        var questions = survey.getActiveQuestions();
+        
+        // SHORT_TEXT 검증
+        assertThat(questions.get(0).getQuestionType()).isEqualTo(QuestionType.SHORT_TEXT);
+        assertThat(questions.get(0).isRequired()).isTrue();
+        assertThat(questions.get(0).getOptions()).isEmpty();
+
+        // SINGLE_CHOICE 검증
+        assertThat(questions.get(1).getQuestionType()).isEqualTo(QuestionType.SINGLE_CHOICE);
+        assertThat(questions.get(1).getOptions()).hasSize(5);
+        assertThat(questions.get(1).getOptions()).contains("1점", "5점");
+
+        // MULTIPLE_CHOICE 검증
+        assertThat(questions.get(2).getQuestionType()).isEqualTo(QuestionType.MULTIPLE_CHOICE);
+        assertThat(questions.get(2).getOptions()).hasSize(6);
+        assertThat(questions.get(2).getOptions()).contains("기술", "디자인", "기타");
+
+        // LONG_TEXT 검증
+        assertThat(questions.get(3).getQuestionType()).isEqualTo(QuestionType.LONG_TEXT);
+        assertThat(questions.get(3).isRequired()).isFalse();
+        assertThat(questions.get(3).getOptions()).isEmpty();
+    }
+
+    @Test
+    @DisplayName("잘못된 요청 데이터로 설문조사 생성 시 400 Bad Request 응답")
+    void 잘못된_요청_데이터_검증() throws Exception {
+        // Given - 제목이 없는 잘못된 요청
+        CreateSurveyRequest invalidRequest = new CreateSurveyRequest(
+                "", // 빈 제목
+                "설명",
+                List.of(
+                        new CreateQuestionRequest(
+                                "질문",
+                                null,
+                                QuestionType.SHORT_TEXT,
+                                false,
+                                null
+                        )
+                )
+        );
+
+        // When
+        String url = "http://localhost:" + port + "/api/surveys";
+        ResponseEntity<String> response = restTemplate.postForEntity(url, invalidRequest, String.class);
+        
+        // Then
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+        assertThat(response.getBody()).isNotNull();
+        
+        var responseBody = objectMapper.readTree(response.getBody());
+        assertThat(responseBody.get("error").asText()).isEqualTo("VALIDATION_FAILED");
+        assertThat(responseBody.get("message").asText()).contains("입력 데이터 검증에 실패했습니다");
+    }
+
+    @Test
+    @DisplayName("질문 개수 초과 시 400 Bad Request 응답")
+    void 질문_개수_초과_검증() throws Exception {
+        // Given - 11개의 질문 (최대 10개 초과)
+        List<CreateQuestionRequest> tooManyQuestions = List.of(
+                new CreateQuestionRequest("질문1", null, QuestionType.SHORT_TEXT, false, null),
+                new CreateQuestionRequest("질문2", null, QuestionType.SHORT_TEXT, false, null),
+                new CreateQuestionRequest("질문3", null, QuestionType.SHORT_TEXT, false, null),
+                new CreateQuestionRequest("질문4", null, QuestionType.SHORT_TEXT, false, null),
+                new CreateQuestionRequest("질문5", null, QuestionType.SHORT_TEXT, false, null),
+                new CreateQuestionRequest("질문6", null, QuestionType.SHORT_TEXT, false, null),
+                new CreateQuestionRequest("질문7", null, QuestionType.SHORT_TEXT, false, null),
+                new CreateQuestionRequest("질문8", null, QuestionType.SHORT_TEXT, false, null),
+                new CreateQuestionRequest("질문9", null, QuestionType.SHORT_TEXT, false, null),
+                new CreateQuestionRequest("질문10", null, QuestionType.SHORT_TEXT, false, null),
+                new CreateQuestionRequest("질문11", null, QuestionType.SHORT_TEXT, false, null)
+        );
+
+        CreateSurveyRequest request = new CreateSurveyRequest(
+                "질문 개수 초과 테스트",
+                "11개 질문 테스트",
+                tooManyQuestions
+        );
+
+        // When
+        String url = "http://localhost:" + port + "/api/surveys";
+        ResponseEntity<String> response = restTemplate.postForEntity(url, request, String.class);
+        
+        // Then
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+        assertThat(response.getBody()).isNotNull();
+        
+        var responseBody = objectMapper.readTree(response.getBody());
+        assertThat(responseBody.get("error").asText()).isEqualTo("VALIDATION_FAILED");
+    }
+}

--- a/project/jooeun-onboarding/survey-api/src/test/resources/application-test.yml
+++ b/project/jooeun-onboarding/survey-api/src/test/resources/application-test.yml
@@ -1,17 +1,34 @@
+server:
+  port: 0  # 랜덤 포트 사용
+
 spring:
   datasource:
-    url: jdbc:h2:mem:test;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
+    url: jdbc:h2:mem:testdb;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
     driver-class-name: org.h2.Driver
     username: sa
     password:
     
+  h2:
+    console:
+      enabled: false  # 테스트에서는 비활성화
+      
   jpa:
     hibernate:
       ddl-auto: create-drop
-    show-sql: false
-    
+    show-sql: false  # 테스트 로그 간소화
+    properties:
+      hibernate:
+        dialect: org.hibernate.dialect.H2Dialect
+        format_sql: false
+        
+  jackson:
+    serialization:
+      write-dates-as-timestamps: false
+
+# 테스트용 로깅 설정
 logging:
   level:
     com.innercircle.survey: INFO
     org.springframework.web: WARN
     org.hibernate.SQL: WARN
+    org.springframework.test: INFO

--- a/project/jooeun-onboarding/survey-domain/src/main/java/com/innercircle/survey/domain/response/SurveyAnswer.java
+++ b/project/jooeun-onboarding/survey-domain/src/main/java/com/innercircle/survey/domain/response/SurveyAnswer.java
@@ -270,6 +270,26 @@ public class SurveyAnswer extends BaseEntity {
     }
 
     /**
+     * 현재 선택지와 비교하여 여전히 유효한 응답인지 확인
+     *
+     * @param currentChoices 현재 질문의 선택지들
+     * @return 유효성 여부
+     */
+    public boolean isStillValidAgainstCurrentChoices(List<String> currentChoices) {
+        if (!isChoiceAnswer()) {
+            return true; // 텍스트 응답은 항상 유효
+        }
+        
+        if (currentChoices == null || currentChoices.isEmpty()) {
+            return false; // 현재 선택지가 없으면 무효
+        }
+        
+        // 모든 응답 값이 현재 선택지에 포함되어 있는지 확인
+        return answerValues.stream()
+                .allMatch(currentChoices::contains);
+    }
+
+    /**
      * 응답의 문자열 표현 (로깅/디버깅용)
      *
      * @return 응답 요약

--- a/project/jooeun-onboarding/survey-infrastructure/src/main/java/com/innercircle/survey/infrastructure/.gitkeep
+++ b/project/jooeun-onboarding/survey-infrastructure/src/main/java/com/innercircle/survey/infrastructure/.gitkeep
@@ -1,1 +1,0 @@
-# Infrastructure module source directory

--- a/project/jooeun-onboarding/survey-infrastructure/src/main/java/com/innercircle/survey/infrastructure/repository/SurveyRepository.java
+++ b/project/jooeun-onboarding/survey-infrastructure/src/main/java/com/innercircle/survey/infrastructure/repository/SurveyRepository.java
@@ -1,0 +1,48 @@
+package com.innercircle.survey.infrastructure.repository;
+
+import com.innercircle.survey.domain.survey.Survey;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+/**
+ * 설문조사 엔티티에 대한 데이터 액세스 인터페이스
+ */
+@Repository
+public interface SurveyRepository extends JpaRepository<Survey, String> {
+
+    /**
+     * 설문조사 ID로 조회 (활성화된 질문들과 함께)
+     *
+     * @param surveyId 설문조사 ID
+     * @return 설문조사
+     */
+    @Query("SELECT s FROM Survey s " +
+           "LEFT JOIN FETCH s.questions q " +
+           "WHERE s.id = :surveyId " +
+           "ORDER BY q.displayOrder ASC")
+    Optional<Survey> findByIdWithQuestions(@Param("surveyId") String surveyId);
+
+    /**
+     * 설문조사 ID로 조회 (활성화된 질문들만)
+     *
+     * @param surveyId 설문조사 ID
+     * @return 설문조사
+     */
+    @Query("SELECT s FROM Survey s " +
+           "LEFT JOIN FETCH s.questions q " +
+           "WHERE s.id = :surveyId AND q.active = true " +
+           "ORDER BY q.displayOrder ASC")
+    Optional<Survey> findByIdWithActiveQuestions(@Param("surveyId") String surveyId);
+
+    /**
+     * 설문조사가 존재하는지 확인
+     *
+     * @param surveyId 설문조사 ID
+     * @return 존재 여부
+     */
+    boolean existsById(String surveyId);
+}


### PR DESCRIPTION
## 목적 : 설문조사 생성 API 구현 

### 구현 내용

**핵심 기능**

* 설문조사 생성 API (`POST /api/surveys`)
* 설문조사 단건 조회 API (`GET /api/surveys/{id}`)
* 설문조사 존재 여부 확인 API (`GET /api/surveys/{id}/exists`)

**기술적 포인트**

* Swagger(OpenAPI) 문서 자동화
* 전역 예외 처리 및 Bean Validation 적용

### 주요 API 정리

| Method | Endpoint                 | 설명            | 상태 코드       |
| ------ | ------------------------ | ------------- | ----------- |
| POST   | /api/surveys             | 설문조사 생성       | 201 Created |
| GET    | /api/surveys/{id}        | 설문조사 상세 조회    | 200 OK      |
| GET    | /api/surveys/{id}/exists | 설문조사 존재 여부 확인 | 200 OK      |

### 테스트

* 통합 테스트: 전체 API 흐름 테스트

### API 요청 예시

```json
{
  "title": "2024년 고객 만족도 조사",
  "description": "고객 서비스 개선을 위한 만족도 조사입니다.",
  "questions": [
    {
      "title": "전반적인 서비스에 만족하십니까?",
      "description": "서비스 전반에 대한 만족도를 평가해 주세요.",
      "questionType": "SINGLE_CHOICE",
      "required": true,
      "options": ["매우 불만족", "불만족", "보통", "만족", "매우 만족"]
    },
    {
      "title": "개선사항을 자유롭게 작성해 주세요.",
      "questionType": "LONG_TEXT",
      "required": false
    }
  ]
}
```

### 다음 단계

* 설문조사 수정 API
* 응답 제출 및 저장 API
* 응답 결과 조회 API
* 조건 기반 검색 기능 (QueryDSL 예정)

issue: #115 