### PR TITLE
[2025-06-14]Question 도메인 및 Survey 도메인 테스트 작성 작업

### DIFF
--- a/project/inung-onboarding/src/main/java/icd/onboarding/surveyproject/service/domain/Option.java
+++ b/project/inung-onboarding/src/main/java/icd/onboarding/surveyproject/service/domain/Option.java
@@ -2,28 +2,29 @@ package icd.onboarding.surveyproject.service.domain;
 
 import lombok.Builder;
 import lombok.Getter;
-import lombok.Setter;
+
 import java.util.UUID;
 
 @Getter
-@Setter
 @Builder
 public class Option {
-	private UUID questionId;
+	private Question question;
 	private UUID id;
 	private String text;
 	private Integer sortOrder;
 
-	public static Option create (UUID questionId, String text, Integer sortOrder) {
-		if (questionId == null) throw new IllegalArgumentException("질문의 Id는 비어 있을 수 없습니다.");
+	public static Option create (String text, Integer sortOrder) {
 		if (text == null || text.isBlank()) throw new IllegalArgumentException("옵션 텍스트는 필수입니다.");
 		if (sortOrder < 0) throw new IllegalArgumentException("정렬 순서는 음수일 수 없습니다.");
 
 		return Option.builder()
-					 .questionId(questionId)
 					 .text(text)
 					 .sortOrder(sortOrder)
 					 .id(UUID.randomUUID())
 					 .build();
+	}
+
+	protected void setQuestion (Question question) {
+		this.question = question;
 	}
 }

--- a/project/inung-onboarding/src/main/java/icd/onboarding/surveyproject/service/domain/Option.java
+++ b/project/inung-onboarding/src/main/java/icd/onboarding/surveyproject/service/domain/Option.java
@@ -1,5 +1,7 @@
 package icd.onboarding.surveyproject.service.domain;
 
+import icd.onboarding.surveyproject.service.exception.InvalidOptionInfoException;
+import icd.onboarding.surveyproject.service.exception.NotNegativeNumberException;
 import io.micrometer.common.util.StringUtils;
 import lombok.Getter;
 
@@ -19,8 +21,8 @@ public class Option {
 	}
 
 	public static Option create (String text, Integer sortOrder) {
-		if (StringUtils.isBlank(text)) throw new IllegalArgumentException("옵션 텍스트는 필수입니다.");
-		if (sortOrder < 0) throw new IllegalArgumentException("정렬 순서는 음수일 수 없습니다.");
+		if (StringUtils.isBlank(text)) throw new InvalidOptionInfoException();
+		if (sortOrder < 0) throw new NotNegativeNumberException();
 
 		return new Option(text, sortOrder);
 	}

--- a/project/inung-onboarding/src/main/java/icd/onboarding/surveyproject/service/domain/Option.java
+++ b/project/inung-onboarding/src/main/java/icd/onboarding/surveyproject/service/domain/Option.java
@@ -1,5 +1,6 @@
 package icd.onboarding.surveyproject.service.domain;
 
+import io.micrometer.common.util.StringUtils;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -14,7 +15,7 @@ public class Option {
 	private Integer sortOrder;
 
 	public static Option create (String text, Integer sortOrder) {
-		if (text == null || text.isBlank()) throw new IllegalArgumentException("옵션 텍스트는 필수입니다.");
+		if (StringUtils.isBlank(text)) throw new IllegalArgumentException("옵션 텍스트는 필수입니다.");
 		if (sortOrder < 0) throw new IllegalArgumentException("정렬 순서는 음수일 수 없습니다.");
 
 		return Option.builder()

--- a/project/inung-onboarding/src/main/java/icd/onboarding/surveyproject/service/domain/Option.java
+++ b/project/inung-onboarding/src/main/java/icd/onboarding/surveyproject/service/domain/Option.java
@@ -1,28 +1,28 @@
 package icd.onboarding.surveyproject.service.domain;
 
 import io.micrometer.common.util.StringUtils;
-import lombok.Builder;
 import lombok.Getter;
 
 import java.util.UUID;
 
 @Getter
-@Builder
 public class Option {
 	private Question question;
-	private UUID id;
-	private String text;
-	private Integer sortOrder;
+	private final UUID id;
+	private final String text;
+	private final Integer sortOrder;
+
+	public Option (String text, Integer sortOrder) {
+		this.id = UUID.randomUUID();
+		this.text = text;
+		this.sortOrder = sortOrder;
+	}
 
 	public static Option create (String text, Integer sortOrder) {
 		if (StringUtils.isBlank(text)) throw new IllegalArgumentException("옵션 텍스트는 필수입니다.");
 		if (sortOrder < 0) throw new IllegalArgumentException("정렬 순서는 음수일 수 없습니다.");
 
-		return Option.builder()
-					 .text(text)
-					 .sortOrder(sortOrder)
-					 .id(UUID.randomUUID())
-					 .build();
+		return new Option(text, sortOrder);
 	}
 
 	protected void setQuestion (Question question) {

--- a/project/inung-onboarding/src/main/java/icd/onboarding/surveyproject/service/domain/Question.java
+++ b/project/inung-onboarding/src/main/java/icd/onboarding/surveyproject/service/domain/Question.java
@@ -4,8 +4,6 @@ import icd.onboarding.surveyproject.service.enums.InputType;
 import icd.onboarding.surveyproject.service.exception.*;
 import io.micrometer.common.util.StringUtils;
 import lombok.Getter;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
 
 import java.util.List;
 import java.util.UUID;
@@ -13,14 +11,14 @@ import java.util.UUID;
 @Getter
 public class Question {
 	private Survey survey;
-	private @Nullable UUID id;
-	private @NotNull String name;
-	private @NotNull String description;
-	private @NotNull InputType inputType;
-	private @Nullable Boolean required;
-	private @NotNull Integer sortOrder;
+	private final UUID id;
+	private final String name;
+	private final String description;
+	private final InputType inputType;
+	private final Boolean required;
+	private final Integer sortOrder;
 
-	private @Nullable List<Option> options;
+	private final List<Option> options;
 
 	private static final int MAX_OPTION_COUNT = 10;
 

--- a/project/inung-onboarding/src/main/java/icd/onboarding/surveyproject/service/domain/Question.java
+++ b/project/inung-onboarding/src/main/java/icd/onboarding/surveyproject/service/domain/Question.java
@@ -1,11 +1,12 @@
 package icd.onboarding.surveyproject.service.domain;
 
 import icd.onboarding.surveyproject.service.enums.InputType;
-import icd.onboarding.surveyproject.service.enums.QuestionErrors;
-import icd.onboarding.surveyproject.service.exception.InvalidQuestionException;
+import icd.onboarding.surveyproject.service.exception.InSufficientOptionException;
+import icd.onboarding.surveyproject.service.exception.InvalidInputTypeException;
+import icd.onboarding.surveyproject.service.exception.InvalidQuestionInfoException;
+import icd.onboarding.surveyproject.service.exception.NotNegativeNumberException;
 import lombok.Builder;
 import lombok.Getter;
-import lombok.Setter;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -13,11 +14,8 @@ import java.util.List;
 import java.util.UUID;
 
 @Getter
-@Setter
-@Builder
 public class Question {
-	private @NotNull UUID surveyId;
-	private @NotNull Integer surveyVersion;
+	private Survey survey;
 	private @Nullable UUID id;
 	private @NotNull String name;
 	private @NotNull String description;
@@ -27,28 +25,36 @@ public class Question {
 
 	private @Nullable List<Option> options;
 
-	public static Question create (UUID surveyId, Integer surveyVersion, String name, String description, String inputType, Boolean required, Integer sortOrder) {
-		if (surveyId == null || surveyVersion == null)
-			throw new InvalidQuestionException(QuestionErrors.INVALID_SURVEY_INFO);
-		if (name == null || name.isBlank())
-			throw new InvalidQuestionException(QuestionErrors.EMPTY_QUESTION_INFO);
-		if (description == null || description.isBlank())
-			throw new InvalidQuestionException(QuestionErrors.EMPTY_QUESTION_INFO);
-		if (sortOrder < 0)
-			throw new InvalidQuestionException(QuestionErrors.NOT_NEGATIVE_NUMBER);
-		if (!InputType.contains(inputType)) {
-			throw new InvalidQuestionException(QuestionErrors.INVALID_INPUT_TYPE);
-		}
+	private Question (String name, String description, String inputType, Boolean required, Integer sortOrder, List<Option> options) {
+		this.name = name;
+		this.description = description;
+		this.inputType = InputType.valueOf(inputType);
+		this.required = required != null ? required : false;
+		this.sortOrder = sortOrder;
+		this.id = UUID.randomUUID();
 
-		return Question.builder()
-					   .id(UUID.randomUUID())
-					   .surveyId(surveyId)
-					   .surveyVersion(surveyVersion)
-					   .name(name)
-					   .description(description)
-					   .inputType(InputType.valueOf(inputType))
-					   .required(required)
-					   .sortOrder(sortOrder)
-					   .build();
+		for (Option option : options) {
+			option.setQuestion(this);
+		}
+		this.options = options;
+	}
+
+	public static Question create (String name, String description, String inputType, Boolean required, Integer sortOrder, List<Option> options) {
+		if (name == null || name.isBlank())
+			throw new InvalidQuestionInfoException();
+		if (description == null || description.isBlank())
+			throw new InvalidQuestionInfoException();
+		if (sortOrder < 0)
+			throw new NotNegativeNumberException();
+		if (!InputType.contains(inputType))
+			throw new InvalidInputTypeException();
+		if (options == null || options.isEmpty())
+			throw new InSufficientOptionException();
+
+		return new Question(name, description, inputType, required, sortOrder, options);
+	}
+
+	protected void setSurvey (Survey survey) {
+		this.survey = survey;
 	}
 }

--- a/project/inung-onboarding/src/main/java/icd/onboarding/surveyproject/service/domain/Question.java
+++ b/project/inung-onboarding/src/main/java/icd/onboarding/surveyproject/service/domain/Question.java
@@ -1,11 +1,8 @@
 package icd.onboarding.surveyproject.service.domain;
 
 import icd.onboarding.surveyproject.service.enums.InputType;
-import icd.onboarding.surveyproject.service.exception.InSufficientOptionException;
-import icd.onboarding.surveyproject.service.exception.InvalidInputTypeException;
-import icd.onboarding.surveyproject.service.exception.InvalidQuestionInfoException;
-import icd.onboarding.surveyproject.service.exception.NotNegativeNumberException;
-import lombok.Builder;
+import icd.onboarding.surveyproject.service.exception.*;
+import io.micrometer.common.util.StringUtils;
 import lombok.Getter;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -25,6 +22,8 @@ public class Question {
 
 	private @Nullable List<Option> options;
 
+	private static final int MAX_OPTION_COUNT = 10;
+
 	private Question (String name, String description, String inputType, Boolean required, Integer sortOrder, List<Option> options) {
 		this.name = name;
 		this.description = description;
@@ -40,9 +39,7 @@ public class Question {
 	}
 
 	public static Question create (String name, String description, String inputType, Boolean required, Integer sortOrder, List<Option> options) {
-		if (name == null || name.isBlank())
-			throw new InvalidQuestionInfoException();
-		if (description == null || description.isBlank())
+		if (StringUtils.isBlank(name) || StringUtils.isBlank(description))
 			throw new InvalidQuestionInfoException();
 		if (sortOrder < 0)
 			throw new NotNegativeNumberException();
@@ -50,6 +47,8 @@ public class Question {
 			throw new InvalidInputTypeException();
 		if (options == null || options.isEmpty())
 			throw new InSufficientOptionException();
+		if (options.size() > MAX_OPTION_COUNT)
+			throw new MaxOptionCountExceededException();
 
 		return new Question(name, description, inputType, required, sortOrder, options);
 	}

--- a/project/inung-onboarding/src/main/java/icd/onboarding/surveyproject/service/domain/Survey.java
+++ b/project/inung-onboarding/src/main/java/icd/onboarding/surveyproject/service/domain/Survey.java
@@ -16,7 +16,7 @@ public class Survey {
 	private final String title;
 	private final String description;
 
-	private List<Question> questions;
+	private final List<Question> questions;
 
 	private static final int MAX_QUESTION_COUNT = 10;
 

--- a/project/inung-onboarding/src/main/java/icd/onboarding/surveyproject/service/domain/Survey.java
+++ b/project/inung-onboarding/src/main/java/icd/onboarding/surveyproject/service/domain/Survey.java
@@ -1,0 +1,38 @@
+package icd.onboarding.surveyproject.service.domain;
+
+import icd.onboarding.surveyproject.service.exception.InSufficientQuestionException;
+import icd.onboarding.surveyproject.service.exception.InValidSurveyInfoException;
+import lombok.Getter;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.UUID;
+
+@Getter
+public class Survey {
+	private final UUID id;
+	private final String title;
+	private final String description;
+
+	private List<Question> questions;
+
+	private Survey (String title, String description, List<Question> questions) {
+		this.title = title;
+		this.description = description;
+		this.id = UUID.randomUUID();
+
+		for (Question question : questions) {
+			question.setSurvey(this);
+		}
+		this.questions = Collections.unmodifiableList(questions);
+	}
+
+	public static Survey create (String title, String description, List<Question> questions) {
+		if (title == null || title.isBlank())
+			throw new InValidSurveyInfoException();
+		if (questions == null || questions.isEmpty())
+			throw new InSufficientQuestionException();
+
+		return new Survey(title, description, questions);
+	}
+}

--- a/project/inung-onboarding/src/main/java/icd/onboarding/surveyproject/service/domain/Survey.java
+++ b/project/inung-onboarding/src/main/java/icd/onboarding/surveyproject/service/domain/Survey.java
@@ -2,6 +2,8 @@ package icd.onboarding.surveyproject.service.domain;
 
 import icd.onboarding.surveyproject.service.exception.InSufficientQuestionException;
 import icd.onboarding.surveyproject.service.exception.InValidSurveyInfoException;
+import icd.onboarding.surveyproject.service.exception.MaxQuestionCountExceededException;
+import io.micrometer.common.util.StringUtils;
 import lombok.Getter;
 
 import java.util.Collections;
@@ -16,6 +18,8 @@ public class Survey {
 
 	private List<Question> questions;
 
+	private static final int MAX_QUESTION_COUNT = 10;
+
 	private Survey (String title, String description, List<Question> questions) {
 		this.title = title;
 		this.description = description;
@@ -28,10 +32,12 @@ public class Survey {
 	}
 
 	public static Survey create (String title, String description, List<Question> questions) {
-		if (title == null || title.isBlank())
+		if (StringUtils.isBlank(title))
 			throw new InValidSurveyInfoException();
 		if (questions == null || questions.isEmpty())
 			throw new InSufficientQuestionException();
+		if (questions.size() > MAX_QUESTION_COUNT)
+			throw new MaxQuestionCountExceededException();
 
 		return new Survey(title, description, questions);
 	}

--- a/project/inung-onboarding/src/main/java/icd/onboarding/surveyproject/service/enums/QuestionErrors.java
+++ b/project/inung-onboarding/src/main/java/icd/onboarding/surveyproject/service/enums/QuestionErrors.java
@@ -1,5 +1,6 @@
 package icd.onboarding.surveyproject.service.enums;
 
+// 차후 Controller의 ErrorCodes 생성 시 합칠 예정
 public enum QuestionErrors {
 	INVALID_SURVEY_INFO("설문에 대한 정보가 없습니다."),
 	EMPTY_QUESTION_INFO("질문 제목 및 설명은 필수 입력 값 입니다."),

--- a/project/inung-onboarding/src/main/java/icd/onboarding/surveyproject/service/exception/InSufficientOptionException.java
+++ b/project/inung-onboarding/src/main/java/icd/onboarding/surveyproject/service/exception/InSufficientOptionException.java
@@ -1,0 +1,4 @@
+package icd.onboarding.surveyproject.service.exception;
+
+public class InSufficientOptionException extends RuntimeException{
+}

--- a/project/inung-onboarding/src/main/java/icd/onboarding/surveyproject/service/exception/InSufficientQuestionException.java
+++ b/project/inung-onboarding/src/main/java/icd/onboarding/surveyproject/service/exception/InSufficientQuestionException.java
@@ -1,0 +1,4 @@
+package icd.onboarding.surveyproject.service.exception;
+
+public class InSufficientQuestionException extends RuntimeException {
+}

--- a/project/inung-onboarding/src/main/java/icd/onboarding/surveyproject/service/exception/InValidSurveyInfoException.java
+++ b/project/inung-onboarding/src/main/java/icd/onboarding/surveyproject/service/exception/InValidSurveyInfoException.java
@@ -1,0 +1,4 @@
+package icd.onboarding.surveyproject.service.exception;
+
+public class InValidSurveyInfoException extends RuntimeException {
+}

--- a/project/inung-onboarding/src/main/java/icd/onboarding/surveyproject/service/exception/InvalidInputTypeException.java
+++ b/project/inung-onboarding/src/main/java/icd/onboarding/surveyproject/service/exception/InvalidInputTypeException.java
@@ -1,0 +1,4 @@
+package icd.onboarding.surveyproject.service.exception;
+
+public class InvalidInputTypeException extends RuntimeException {
+}

--- a/project/inung-onboarding/src/main/java/icd/onboarding/surveyproject/service/exception/InvalidOptionInfoException.java
+++ b/project/inung-onboarding/src/main/java/icd/onboarding/surveyproject/service/exception/InvalidOptionInfoException.java
@@ -1,0 +1,4 @@
+package icd.onboarding.surveyproject.service.exception;
+
+public class InvalidOptionInfoException extends RuntimeException{
+}

--- a/project/inung-onboarding/src/main/java/icd/onboarding/surveyproject/service/exception/InvalidQuestionException.java
+++ b/project/inung-onboarding/src/main/java/icd/onboarding/surveyproject/service/exception/InvalidQuestionException.java
@@ -1,9 +1,0 @@
-package icd.onboarding.surveyproject.service.exception;
-
-import icd.onboarding.surveyproject.service.enums.QuestionErrors;
-
-public class InvalidQuestionException extends IllegalArgumentException{
-	public InvalidQuestionException(QuestionErrors questionError) {
-		super(questionError.value());
-	}
-}

--- a/project/inung-onboarding/src/main/java/icd/onboarding/surveyproject/service/exception/InvalidQuestionInfoException.java
+++ b/project/inung-onboarding/src/main/java/icd/onboarding/surveyproject/service/exception/InvalidQuestionInfoException.java
@@ -1,0 +1,4 @@
+package icd.onboarding.surveyproject.service.exception;
+
+public class InvalidQuestionInfoException extends RuntimeException {
+}

--- a/project/inung-onboarding/src/main/java/icd/onboarding/surveyproject/service/exception/MaxOptionCountExceededException.java
+++ b/project/inung-onboarding/src/main/java/icd/onboarding/surveyproject/service/exception/MaxOptionCountExceededException.java
@@ -1,0 +1,4 @@
+package icd.onboarding.surveyproject.service.exception;
+
+public class MaxOptionCountExceededException extends RuntimeException {
+}

--- a/project/inung-onboarding/src/main/java/icd/onboarding/surveyproject/service/exception/MaxQuestionCountExceededException.java
+++ b/project/inung-onboarding/src/main/java/icd/onboarding/surveyproject/service/exception/MaxQuestionCountExceededException.java
@@ -1,0 +1,4 @@
+package icd.onboarding.surveyproject.service.exception;
+
+public class MaxQuestionCountExceededException extends RuntimeException {
+}

--- a/project/inung-onboarding/src/main/java/icd/onboarding/surveyproject/service/exception/NotNegativeNumberException.java
+++ b/project/inung-onboarding/src/main/java/icd/onboarding/surveyproject/service/exception/NotNegativeNumberException.java
@@ -1,0 +1,4 @@
+package icd.onboarding.surveyproject.service.exception;
+
+public class NotNegativeNumberException extends RuntimeException{
+}

--- a/project/inung-onboarding/src/test/java/icd/onboarding/surveyproject/fixtures/QuestionFixtures.java
+++ b/project/inung-onboarding/src/test/java/icd/onboarding/surveyproject/fixtures/QuestionFixtures.java
@@ -1,0 +1,20 @@
+package icd.onboarding.surveyproject.fixtures;
+
+import icd.onboarding.surveyproject.service.domain.Option;
+import icd.onboarding.surveyproject.service.domain.Question;
+
+import java.util.List;
+
+public class QuestionFixtures {
+	public static Question basicQuestion () {
+		List<Option> options = List.of(Option.create("옵션 1", 1));
+		return Question.create(
+				"질문 1",
+				"질문 설명",
+				"SHORT_TEXT",
+				true,
+				1,
+				options
+		);
+	}
+}

--- a/project/inung-onboarding/src/test/java/icd/onboarding/surveyproject/fixtures/SurveyFixtures.java
+++ b/project/inung-onboarding/src/test/java/icd/onboarding/surveyproject/fixtures/SurveyFixtures.java
@@ -1,0 +1,13 @@
+package icd.onboarding.surveyproject.fixtures;
+
+import icd.onboarding.surveyproject.service.domain.Question;
+import icd.onboarding.surveyproject.service.domain.Survey;
+
+import java.util.List;
+
+public class SurveyFixtures {
+	public static Survey basicSurvey () {
+		List<Question> questions = List.of(QuestionFixtures.basicQuestion());
+		return Survey.create("설문 조사 1", "설문 조사 양식", questions);
+	}
+}

--- a/project/inung-onboarding/src/test/java/icd/onboarding/surveyproject/service/domain/OptionTest.java
+++ b/project/inung-onboarding/src/test/java/icd/onboarding/surveyproject/service/domain/OptionTest.java
@@ -1,5 +1,7 @@
 package icd.onboarding.surveyproject.service.domain;
 
+import icd.onboarding.surveyproject.service.exception.InvalidOptionInfoException;
+import icd.onboarding.surveyproject.service.exception.NotNegativeNumberException;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -15,24 +17,15 @@ class OptionTest {
 	@NullAndEmptySource
 	@DisplayName("옵션 값이 null이거나 비어 있으면 예외를 반환 합니다.")
 	void throwExceptionWhenOptionTextIsNullAndEmpty (String text) {
-
-		// when
-		Exception ex = assertThrows(IllegalArgumentException.class, () -> Option.create(text, validSortOrder));
-
-		// then
-		String expected = "옵션 텍스트는 필수입니다.";
-		assertEquals(expected, ex.getMessage());
+		// when & then
+		assertThrows(InvalidOptionInfoException.class, () -> Option.create(text, validSortOrder));
 	}
 
 	@Test
 	@DisplayName("옵션의 sortOrder가 음수일 경우 예외를 반환 합니다.")
 	void throwExceptionWhenOptionSortOrderIsNegativeNumber () {
-		// when
-		Exception ex = assertThrows(IllegalArgumentException.class, () -> Option.create(validText, -1));
-
-		// then
-		String expected = "정렬 순서는 음수일 수 없습니다.";
-		assertEquals(expected, ex.getMessage());
+		// when & then
+		assertThrows(NotNegativeNumberException.class, () -> Option.create(validText, -1));
 	}
 
 	@Test

--- a/project/inung-onboarding/src/test/java/icd/onboarding/surveyproject/service/domain/OptionTest.java
+++ b/project/inung-onboarding/src/test/java/icd/onboarding/surveyproject/service/domain/OptionTest.java
@@ -5,12 +5,9 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.NullAndEmptySource;
 
-import java.util.UUID;
-
 import static org.junit.jupiter.api.Assertions.*;
 
 class OptionTest {
-	final UUID validQuestionId = UUID.randomUUID();
 	final String validText = "옵션 1";
 	final Integer validSortOrder = 1;
 
@@ -18,8 +15,9 @@ class OptionTest {
 	@NullAndEmptySource
 	@DisplayName("옵션 값이 null이거나 비어 있으면 예외를 반환 합니다.")
 	void throwExceptionWhenOptionTextIsNullAndEmpty (String text) {
+
 		// when
-		Exception ex = assertThrows(IllegalArgumentException.class, () -> Option.create(validQuestionId, text, validSortOrder));
+		Exception ex = assertThrows(IllegalArgumentException.class, () -> Option.create(text, validSortOrder));
 
 		// then
 		String expected = "옵션 텍스트는 필수입니다.";
@@ -30,7 +28,7 @@ class OptionTest {
 	@DisplayName("옵션의 sortOrder가 음수일 경우 예외를 반환 합니다.")
 	void throwExceptionWhenOptionSortOrderIsNegativeNumber () {
 		// when
-		Exception ex = assertThrows(IllegalArgumentException.class, () -> Option.create(validQuestionId, validText, -1));
+		Exception ex = assertThrows(IllegalArgumentException.class, () -> Option.create(validText, -1));
 
 		// then
 		String expected = "정렬 순서는 음수일 수 없습니다.";
@@ -38,26 +36,14 @@ class OptionTest {
 	}
 
 	@Test
-	@DisplayName("옵션의 questionId가 비어 있으면 예외를 반환 합니다.")
-	void throwExceptionWhenOptionQuestionIdIsNull () {
-		// when
-		Exception ex = assertThrows(IllegalArgumentException.class, () -> Option.create(null, validText, validSortOrder));
-
-		// then
-		String expected = "질문의 Id는 비어 있을 수 없습니다.";
-		assertEquals(expected, ex.getMessage());
-	}
-
-	@Test
 	@DisplayName("옵션의 값과 ID가 유효하며, sortOrder가 음수가 아니면 객체가 생성됩니다.")
 	void shouldCreateOptionWhenInputsAreValid () {
 		// when
-		Option option = Option.create(validQuestionId, validText, validSortOrder);
+		Option option = Option.create(validText, validSortOrder);
 
 		// then
 		assertNotNull(option);
 		assertNotNull(option.getId());
-		assertEquals(validQuestionId, option.getQuestionId());
 		assertEquals(validText, option.getText());
 		assertEquals(validSortOrder, option.getSortOrder());
 	}

--- a/project/inung-onboarding/src/test/java/icd/onboarding/surveyproject/service/domain/QuestionTest.java
+++ b/project/inung-onboarding/src/test/java/icd/onboarding/surveyproject/service/domain/QuestionTest.java
@@ -1,103 +1,86 @@
 package icd.onboarding.surveyproject.service.domain;
 
-import icd.onboarding.surveyproject.common.NotImplementedTestException;
 import icd.onboarding.surveyproject.service.enums.InputType;
-import icd.onboarding.surveyproject.service.enums.QuestionErrors;
-import icd.onboarding.surveyproject.service.exception.InvalidQuestionException;
+import icd.onboarding.surveyproject.service.exception.InSufficientOptionException;
+import icd.onboarding.surveyproject.service.exception.InvalidInputTypeException;
+import icd.onboarding.surveyproject.service.exception.InvalidQuestionInfoException;
+import icd.onboarding.surveyproject.service.exception.NotNegativeNumberException;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
-import org.junit.jupiter.params.provider.CsvSources;
 import org.junit.jupiter.params.provider.ValueSource;
-import org.junit.jupiter.params.provider.ValueSources;
 
-import java.util.UUID;
+import java.util.Collections;
+import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.*;
 
 class QuestionTest {
-	final UUID validSurveyId = UUID.randomUUID();
-	final Integer validSurveyVersion = 1;
 	final String validName = "질문 1";
 	final String validDescription = "질문 설명";
 	final Integer validSortOrder = 1;
 	final String validInputType = "SHORT_TEXT";
 	final Boolean validRequired = true;
-
-	@Test
-	@DisplayName("설문 id 및 버전이 null인 경우 예외를 반환 한다.")
-	void throwWhenQuestionSurveyInfoIsNull () {
-		// when
-		Exception ex = assertThrows(
-				InvalidQuestionException.class,
-				() -> Question.create(null, null, validName, validDescription, validInputType, validRequired, validSortOrder)
-		);
-
-		// then
-		assertEquals(QuestionErrors.INVALID_SURVEY_INFO.value(), ex.getMessage());
-	}
+	final List<Option> validOptions = List.of(Option.create("옵션 1", 1));
 
 	@ParameterizedTest
 	@CsvSource({"null, ''", "'', null"})
 	@DisplayName("질문의 이름, 설명이 null이거나 비어있는 경우 예외를 반환 한다.")
-	void throwWhenQuestionNameOrDescriptionIsNullAndEmpty (String name, String description) {
-		// when
-		Exception ex = assertThrows(
-				InvalidQuestionException.class,
-				() -> Question.create(validSurveyId, validSurveyVersion, name, description, validInputType, validRequired, validSortOrder)
+	void throwWhenQuestionNameOrDescriptionIsNullAndEmpty (String invalidName, String invalidDescription) {
+		// when & then
+		assertThrows(
+				InvalidQuestionInfoException.class,
+				() -> Question.create(invalidName, invalidDescription, validInputType, validRequired, validSortOrder, validOptions)
 		);
-
-		// then
-		assertEquals(QuestionErrors.EMPTY_QUESTION_INFO.value(), ex.getMessage());
 	}
 
 	@Test
 	@DisplayName("질문의 정렬 순서가 음수인 경우 예외를 반환 한다.")
 	void throwWhenQuestionSortOrderIsNegativeNumber () {
-		// when
-		Exception ex = assertThrows(
-				InvalidQuestionException.class,
-				() -> Question.create(validSurveyId, validSurveyVersion, validName, validDescription, validInputType, validRequired, -1)
+		// when & then
+		assertThrows(
+				NotNegativeNumberException.class,
+				() -> Question.create(validName, validDescription, validInputType, validRequired, -1, validOptions)
 		);
-
-		// then
-		assertEquals(QuestionErrors.NOT_NEGATIVE_NUMBER.value(), ex.getMessage());
 	}
 
 	@Test
 	@DisplayName("입력 형태가 InputType Enum에 포함되지 않은 경우 예외를 반환 한다.")
 	void throwWhenQuestionInputTypeIsNotContains () {
-		// when
-		Exception ex = assertThrows(
-				InvalidQuestionException.class,
-				() -> Question.create(validSurveyId, validSurveyVersion, validName, validDescription, "INVALID_TYPE", validRequired, validSortOrder)
+		// when & Then
+		assertThrows(
+				InvalidInputTypeException.class,
+				() -> Question.create(validName, validDescription, "INVALID_TYPE", validRequired, validSortOrder, validOptions)
 		);
-
-		// then
-		assertEquals(QuestionErrors.INVALID_INPUT_TYPE.value(), ex.getMessage());
 	}
 
-	@Test
-	@DisplayName("입력 형태가 SINGLE_SELECT, MULTI_SELECT 경우 옵션이 최소 1개 이상 존재해야 한다.")
-	void throwWhenQuestionOptionsIsEmpty () {
-		throw new NotImplementedTestException();
+	@ParameterizedTest
+	@ValueSource(strings = {"SINGLE_SELECT", "MULTI_SELECT"})
+	@DisplayName("입력 형태가 SINGLE_SELECT, MULTI_SELECT인 경우 옵션이 존재하지 않으면 예외를 반환 한다.")
+	void throwWhenQuestionOptionsIsEmpty (String inputType) {
+		// given
+		List<Option> emptyOptions = Collections.emptyList();
+
+		// when
+		assertThrows(
+				InSufficientOptionException.class,
+				() -> Question.create(validName, validDescription, inputType, validRequired, validSortOrder, emptyOptions)
+		);
 	}
 
 	@Test
 	@DisplayName("질문의 입력 값에 이상이 없는 경우 정상적으로 객체가 생성됩니다.")
 	void shouldCreateQuestionWhenInputsAreValid () {
 		// when
-		Question question = Question.create(validSurveyId, validSurveyVersion, validName, validDescription, validInputType, validRequired, validSortOrder);
+		Question question = Question.create(validName, validDescription, validInputType, validRequired, validSortOrder, validOptions);
 
 		// then
 		assertNotNull(question);
 		assertNotNull(question.getId());
-		assertEquals(validSurveyId, question.getSurveyId());
-		assertEquals(validSurveyVersion, question.getSurveyVersion());
 		assertEquals(validName, question.getName());
 		assertEquals(validDescription, question.getDescription());
-		assertEquals(validInputType, question.getInputType());
+		assertEquals(InputType.valueOf(validInputType), question.getInputType());
 		assertEquals(validRequired, question.getRequired());
 		assertEquals(validSortOrder, question.getSortOrder());
 	}

--- a/project/inung-onboarding/src/test/java/icd/onboarding/surveyproject/service/domain/QuestionTest.java
+++ b/project/inung-onboarding/src/test/java/icd/onboarding/surveyproject/service/domain/QuestionTest.java
@@ -1,10 +1,7 @@
 package icd.onboarding.surveyproject.service.domain;
 
 import icd.onboarding.surveyproject.service.enums.InputType;
-import icd.onboarding.surveyproject.service.exception.InSufficientOptionException;
-import icd.onboarding.surveyproject.service.exception.InvalidInputTypeException;
-import icd.onboarding.surveyproject.service.exception.InvalidQuestionInfoException;
-import icd.onboarding.surveyproject.service.exception.NotNegativeNumberException;
+import icd.onboarding.surveyproject.service.exception.*;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -13,6 +10,7 @@ import org.junit.jupiter.params.provider.ValueSource;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.stream.IntStream;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -66,6 +64,21 @@ class QuestionTest {
 		assertThrows(
 				InSufficientOptionException.class,
 				() -> Question.create(validName, validDescription, inputType, validRequired, validSortOrder, emptyOptions)
+		);
+	}
+
+	@Test
+	@DisplayName("입력 형태가 SINGLE_SELECT, MULTI_SELECT인 경우 옵션이 10개 이상이면 예외를 반환 한다.")
+	void throwWhenQuestionOptionIsOver10Count () {
+		// given
+		List<Option> overCountOptions = IntStream.rangeClosed(1, 11)
+												 .mapToObj(i -> Option.create("질문 " + i, i))
+												 .toList();
+
+		// when
+		assertThrows(
+				MaxOptionCountExceededException.class,
+				() -> Question.create(validName, validDescription, validInputType, validRequired, validSortOrder, overCountOptions)
 		);
 	}
 

--- a/project/inung-onboarding/src/test/java/icd/onboarding/surveyproject/service/domain/SurveyTest.java
+++ b/project/inung-onboarding/src/test/java/icd/onboarding/surveyproject/service/domain/SurveyTest.java
@@ -3,6 +3,7 @@ package icd.onboarding.surveyproject.service.domain;
 import icd.onboarding.surveyproject.fixtures.QuestionFixtures;
 import icd.onboarding.surveyproject.service.exception.InSufficientQuestionException;
 import icd.onboarding.surveyproject.service.exception.InValidSurveyInfoException;
+import icd.onboarding.surveyproject.service.exception.MaxQuestionCountExceededException;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -10,6 +11,7 @@ import org.junit.jupiter.params.provider.NullAndEmptySource;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.stream.IntStream;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -39,6 +41,21 @@ class SurveyTest {
 		assertThrows(
 				InSufficientQuestionException.class,
 				() -> Survey.create("설문 조사 1", "설문 조사에 대한 설명", emptyQuestions)
+		);
+	}
+
+	@Test
+	@DisplayName("설문 조사의 질문이 10개를 초과한 경우 예외를 반환 한다.")
+	void throwWhenQuestionIsOver10Count () {
+		// given
+		List<Question> overCountQuestions = IntStream.rangeClosed(1, 11)
+													 .mapToObj(i -> QuestionFixtures.basicQuestion())
+													 .toList();
+
+		// when
+		assertThrows(
+				MaxQuestionCountExceededException.class,
+				() -> Survey.create("설문 조사 1", "설문 조사에 대한 설명", overCountQuestions)
 		);
 	}
 }

--- a/project/inung-onboarding/src/test/java/icd/onboarding/surveyproject/service/domain/SurveyTest.java
+++ b/project/inung-onboarding/src/test/java/icd/onboarding/surveyproject/service/domain/SurveyTest.java
@@ -1,0 +1,44 @@
+package icd.onboarding.surveyproject.service.domain;
+
+import icd.onboarding.surveyproject.fixtures.QuestionFixtures;
+import icd.onboarding.surveyproject.service.exception.InSufficientQuestionException;
+import icd.onboarding.surveyproject.service.exception.InValidSurveyInfoException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class SurveyTest {
+
+	@ParameterizedTest
+	@NullAndEmptySource
+	@DisplayName("설문 조사 이름이 null 또는 비어있는 경우 예외를 반환 한다.")
+	void throwExceptionWhenSurveyNameIsNullAndEmpty (String invalidTitle) {
+		// given
+		List<Question> questions = List.of(QuestionFixtures.basicQuestion());
+
+		// when & then
+		assertThrows(
+				InValidSurveyInfoException.class,
+				() -> Survey.create(invalidTitle, "설문 조사에 대한 설명", questions)
+		);
+	}
+
+	@Test
+	@DisplayName("설문 조사의 질문이 비어있는 경우 예외를 반환 한다.")
+	void throwExceptionWhenQuestionsIsEmpty () {
+		// given
+		List<Question> emptyQuestions = Collections.emptyList();
+
+		// when & then
+		assertThrows(
+				InSufficientQuestionException.class,
+				() -> Survey.create("설문 조사 1", "설문 조사에 대한 설명", emptyQuestions)
+		);
+	}
+}


### PR DESCRIPTION
### 💻 테스트 구현 사항
**Question**
- 질문 유형이 `SINGLE_SELECT`, `MULTI_SELECT`일 경우 옵션 최소 1개 이상
- 질문 유형이 `SINGLE_SELECT`, `MULTI_SELECT`일 경우 옵션 최대 10개 이하

**Survey**
- 설문 이름 누락 여부
- 질문 최소 1개 이상 보유
- 질문 최대 10개 이하 보유

### 📍 추가 검토 사항
**예외 처리**
- 기존에는 도메인별 커스텀 예외와 enum을 생성하여 처리
- enum을 도메인별로 분리하여 관리하기에는 컨텍스트 스위칭이 빈번하게 발생
- 또한, 도메인 계층 테스트 시 메시지 비교에 대한 테스트 코드 작성 불편함 발생
- 위 문제를 해결하기 위해 각 예외 사항에 대한 커스텀 예외만 추가
- 차후 controller 계층에서 해당 예외를 확인하고, 공통된 enum을 통해 처리 예정