### PR TITLE
[2025-06-14-hajin-onboarding] 설문조사 응답 검색 기능 추가

### DIFF
--- a/project/hajin-onboarding/README.md
+++ b/project/hajin-onboarding/README.md
@@ -85,6 +85,10 @@ src/main/kotlin/com/innercircle/survey/
 - `GET /api/v1/surveys/{surveyId}/responses`
 - 특정 설문조사의 응답 목록을 페이징하여 조회합니다.
 - `?summary=true` 파라미터로 요약 정보만 조회 가능
+- **검색 기능 (Advanced)**:
+  - `?questionTitle=검색어` - 질문 제목으로 검색 (부분 일치)
+  - `?answerValue=검색어` - 응답 값으로 검색 (텍스트 응답 및 선택지 텍스트 부분 일치)
+  - 두 파라미터를 함께 사용하여 AND 조건 검색 가능
 
 자세한 API 명세는 [API 문서](docs/)를 참고하시거나 실행 후 `/swagger-ui.html`에서 확인하세요.
 

--- a/project/hajin-onboarding/src/main/kotlin/com/innercircle/survey/response/adapter/in/web/ResponseController.kt
+++ b/project/hajin-onboarding/src/main/kotlin/com/innercircle/survey/response/adapter/in/web/ResponseController.kt
@@ -107,7 +107,8 @@ class ResponseController(
 
     @Operation(
         summary = "설문조사별 응답 목록 조회",
-        description = "특정 설문조사에 대한 응답 목록을 페이징하여 조회합니다. " +
+        description =
+            "특정 설문조사에 대한 응답 목록을 페이징하여 조회합니다. " +
                 "summary=true 파라미터로 요약 정보만 조회할 수 있습니다. " +
                 "questionTitle과 answerValue 파라미터로 특정 항목의 응답을 검색할 수 있습니다.",
     )
@@ -136,10 +137,10 @@ class ResponseController(
         @Parameter(description = "검색할 응답 값 (부분 일치)")
         @RequestParam(required = false) answerValue: String?,
     ): ResponseEntity<*> {
-        logger.info { 
+        logger.info {
             "Get responses request received for survey: $surveyId, " +
-            "page=${pageRequest.page}, size=${pageRequest.size}, summary=$summary, " +
-            "questionTitle=$questionTitle, answerValue=$answerValue" 
+                "page=${pageRequest.page}, size=${pageRequest.size}, summary=$summary, " +
+                "questionTitle=$questionTitle, answerValue=$answerValue"
         }
 
         val pageable = pageRequest.toPageable()
@@ -151,16 +152,18 @@ class ResponseController(
             ResponseEntity.ok(response)
         } else {
             // 전체 정보 조회 (검색 조건 포함)
-            val responsesPage = if (questionTitle != null || answerValue != null) {
-                val searchCriteria = ResponseUseCase.ResponseSearchCriteria(
-                    surveyId = surveyId,
-                    questionTitle = questionTitle,
-                    answerValue = answerValue,
-                )
-                responseUseCase.searchResponses(searchCriteria, pageable)
-            } else {
-                responseUseCase.getResponsesBySurveyId(surveyId, pageable)
-            }
+            val responsesPage =
+                if (questionTitle != null || answerValue != null) {
+                    val searchCriteria =
+                        ResponseUseCase.ResponseSearchCriteria(
+                            surveyId = surveyId,
+                            questionTitle = questionTitle,
+                            answerValue = answerValue,
+                        )
+                    responseUseCase.searchResponses(searchCriteria, pageable)
+                } else {
+                    responseUseCase.getResponsesBySurveyId(surveyId, pageable)
+                }
             val response = PageResponse.of(responsesPage) { it.toDto() }
             ResponseEntity.ok(response)
         }

--- a/project/hajin-onboarding/src/main/kotlin/com/innercircle/survey/response/adapter/out/persistence/ResponseJpaRepository.kt
+++ b/project/hajin-onboarding/src/main/kotlin/com/innercircle/survey/response/adapter/out/persistence/ResponseJpaRepository.kt
@@ -32,7 +32,10 @@ interface ResponseJpaRepository : JpaRepository<Response, UUID> {
 
     @Query(
         """
-        SELECT r FROM Response r 
+        SELECT DISTINCT r FROM Response r 
+        LEFT JOIN FETCH r._answers a
+        LEFT JOIN FETCH a.selectedChoiceIds
+        LEFT JOIN FETCH a.selectedChoiceTexts
         WHERE r.survey.id = :surveyId 
         ORDER BY r.createdAt DESC
     """,
@@ -44,7 +47,9 @@ interface ResponseJpaRepository : JpaRepository<Response, UUID> {
     @Query(
         value = """
         SELECT DISTINCT r FROM Response r 
-        LEFT JOIN FETCH r._answers 
+        LEFT JOIN FETCH r._answers a
+        LEFT JOIN FETCH a.selectedChoiceIds
+        LEFT JOIN FETCH a.selectedChoiceTexts
         WHERE r.survey.id = :surveyId
         ORDER BY r.createdAt DESC
     """,
@@ -72,4 +77,6 @@ interface ResponseJpaRepository : JpaRepository<Response, UUID> {
         @Param("surveyId") surveyId: UUID,
         pageable: Pageable,
     ): Page<ResponseSummaryProjection>
+
+
 }

--- a/project/hajin-onboarding/src/main/kotlin/com/innercircle/survey/response/adapter/out/persistence/ResponseJpaRepository.kt
+++ b/project/hajin-onboarding/src/main/kotlin/com/innercircle/survey/response/adapter/out/persistence/ResponseJpaRepository.kt
@@ -78,5 +78,34 @@ interface ResponseJpaRepository : JpaRepository<Response, UUID> {
         pageable: Pageable,
     ): Page<ResponseSummaryProjection>
 
-
+    @Query(
+        value = """
+        SELECT DISTINCT r FROM Response r 
+        LEFT JOIN FETCH r._answers a
+        LEFT JOIN FETCH a.selectedChoiceIds
+        LEFT JOIN FETCH a.selectedChoiceTexts ct
+        WHERE r.survey.id = :surveyId
+        AND (:questionTitle IS NULL OR LOWER(a.questionTitle) LIKE LOWER(CONCAT('%', :questionTitle, '%')))
+        AND (:answerValue IS NULL OR 
+            (LOWER(a.textValue) LIKE LOWER(CONCAT('%', :answerValue, '%')) OR 
+             EXISTS (SELECT 1 FROM a.selectedChoiceTexts sct WHERE LOWER(sct) LIKE LOWER(CONCAT('%', :answerValue, '%')))))
+        ORDER BY r.createdAt DESC
+    """,
+        countQuery = """
+        SELECT COUNT(DISTINCT r) FROM Response r 
+        LEFT JOIN r._answers a
+        LEFT JOIN a.selectedChoiceTexts ct
+        WHERE r.survey.id = :surveyId
+        AND (:questionTitle IS NULL OR LOWER(a.questionTitle) LIKE LOWER(CONCAT('%', :questionTitle, '%')))
+        AND (:answerValue IS NULL OR 
+            (LOWER(a.textValue) LIKE LOWER(CONCAT('%', :answerValue, '%')) OR 
+             EXISTS (SELECT 1 FROM a.selectedChoiceTexts sct WHERE LOWER(sct) LIKE LOWER(CONCAT('%', :answerValue, '%')))))
+    """,
+    )
+    fun searchResponsesByCriteria(
+        @Param("surveyId") surveyId: UUID,
+        @Param("questionTitle") questionTitle: String?,
+        @Param("answerValue") answerValue: String?,
+        pageable: Pageable,
+    ): Page<Response>
 }

--- a/project/hajin-onboarding/src/main/kotlin/com/innercircle/survey/response/adapter/out/persistence/ResponsePersistenceAdapter.kt
+++ b/project/hajin-onboarding/src/main/kotlin/com/innercircle/survey/response/adapter/out/persistence/ResponsePersistenceAdapter.kt
@@ -1,6 +1,7 @@
 package com.innercircle.survey.response.adapter.out.persistence
 
 import com.innercircle.survey.response.adapter.out.persistence.dto.ResponseSummaryProjection
+import com.innercircle.survey.response.application.port.`in`.ResponseUseCase.ResponseSearchCriteria
 import com.innercircle.survey.response.application.port.out.ResponseRepository
 import com.innercircle.survey.response.domain.Response
 import org.springframework.data.domain.Page
@@ -36,5 +37,16 @@ class ResponsePersistenceAdapter(
         pageable: Pageable,
     ): Page<ResponseSummaryProjection> {
         return responseJpaRepository.findResponseSummariesBySurveyId(surveyId, pageable)
+    }
+
+    override fun searchResponsesByCriteria(
+        criteria: ResponseSearchCriteria,
+        pageable: Pageable,
+    ): Page<Response> {
+        // 일단 기본 쿼리만 사용
+        return responseJpaRepository.findBySurveyIdWithAnswers(
+            surveyId = criteria.surveyId,
+            pageable = pageable,
+        )
     }
 }

--- a/project/hajin-onboarding/src/main/kotlin/com/innercircle/survey/response/adapter/out/persistence/ResponsePersistenceAdapter.kt
+++ b/project/hajin-onboarding/src/main/kotlin/com/innercircle/survey/response/adapter/out/persistence/ResponsePersistenceAdapter.kt
@@ -43,9 +43,10 @@ class ResponsePersistenceAdapter(
         criteria: ResponseSearchCriteria,
         pageable: Pageable,
     ): Page<Response> {
-        // 일단 기본 쿼리만 사용
-        return responseJpaRepository.findBySurveyIdWithAnswers(
+        return responseJpaRepository.searchResponsesByCriteria(
             surveyId = criteria.surveyId,
+            questionTitle = criteria.questionTitle,
+            answerValue = criteria.answerValue,
             pageable = pageable,
         )
     }

--- a/project/hajin-onboarding/src/main/kotlin/com/innercircle/survey/response/application/port/in/ResponseUseCase.kt
+++ b/project/hajin-onboarding/src/main/kotlin/com/innercircle/survey/response/application/port/in/ResponseUseCase.kt
@@ -24,6 +24,12 @@ interface ResponseUseCase {
         pageable: Pageable,
     ): Page<ResponseSummaryProjection>
 
+    // 응답 검색 (항목 이름과 응답 값 기반)
+    fun searchResponses(
+        criteria: ResponseSearchCriteria,
+        pageable: Pageable,
+    ): Page<Response>
+
     data class SubmitResponseCommand(
         val surveyId: UUID,
         val respondentId: String? = null,
@@ -35,4 +41,10 @@ interface ResponseUseCase {
             val selectedChoiceIds: Set<UUID>? = null,
         )
     }
+
+    data class ResponseSearchCriteria(
+        val surveyId: UUID,
+        val questionTitle: String? = null,
+        val answerValue: String? = null,
+    )
 }

--- a/project/hajin-onboarding/src/main/kotlin/com/innercircle/survey/response/application/port/out/ResponseRepository.kt
+++ b/project/hajin-onboarding/src/main/kotlin/com/innercircle/survey/response/application/port/out/ResponseRepository.kt
@@ -1,6 +1,7 @@
 package com.innercircle.survey.response.application.port.out
 
 import com.innercircle.survey.response.adapter.out.persistence.dto.ResponseSummaryProjection
+import com.innercircle.survey.response.application.port.`in`.ResponseUseCase.ResponseSearchCriteria
 import com.innercircle.survey.response.domain.Response
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
@@ -22,4 +23,9 @@ interface ResponseRepository {
         surveyId: UUID,
         pageable: Pageable,
     ): Page<ResponseSummaryProjection>
+
+    fun searchResponsesByCriteria(
+        criteria: ResponseSearchCriteria,
+        pageable: Pageable,
+    ): Page<Response>
 }

--- a/project/hajin-onboarding/src/main/kotlin/com/innercircle/survey/response/application/service/ResponseService.kt
+++ b/project/hajin-onboarding/src/main/kotlin/com/innercircle/survey/response/application/service/ResponseService.kt
@@ -16,7 +16,6 @@ import com.innercircle.survey.survey.domain.Question
 import com.innercircle.survey.survey.domain.exception.SurveyNotFoundException
 import mu.KotlinLogging
 import org.springframework.data.domain.Page
-import org.springframework.data.domain.PageImpl
 import org.springframework.data.domain.Pageable
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -74,8 +73,8 @@ class ResponseService(
         surveyId: UUID,
         pageable: Pageable,
     ): Page<Response> {
-        logger.debug { 
-            "Loading responses for survey: $surveyId, page=${pageable.pageNumber}, size=${pageable.pageSize}" 
+        logger.debug {
+            "Loading responses for survey: $surveyId, page=${pageable.pageNumber}, size=${pageable.pageSize}"
         }
 
         // 설문조사 존재 여부 확인
@@ -91,8 +90,8 @@ class ResponseService(
         surveyId: UUID,
         pageable: Pageable,
     ): Page<ResponseSummaryProjection> {
-        logger.debug { 
-            "Loading response summaries for survey: $surveyId, page=${pageable.pageNumber}, size=${pageable.pageSize}" 
+        logger.debug {
+            "Loading response summaries for survey: $surveyId, page=${pageable.pageNumber}, size=${pageable.pageSize}"
         }
 
         // 설문조사 존재 여부 확인
@@ -108,62 +107,18 @@ class ResponseService(
         criteria: ResponseSearchCriteria,
         pageable: Pageable,
     ): Page<Response> {
-        logger.debug { 
+        logger.debug {
             "Searching responses for survey: ${criteria.surveyId}, " +
-            "questionTitle=${criteria.questionTitle}, answerValue=${criteria.answerValue}, " +
-            "page=${pageable.pageNumber}, size=${pageable.pageSize}" 
+                "questionTitle=${criteria.questionTitle}, answerValue=${criteria.answerValue}, " +
+                "page=${pageable.pageNumber}, size=${pageable.pageSize}"
         }
 
         // 설문조사 존재 여부 확인
         surveyRepository.findById(criteria.surveyId)
             ?: throw SurveyNotFoundException(criteria.surveyId)
 
-        // 전체 응답을 가져와서 메모리에서 필터링
-        val allResponses = responseRepository.findBySurveyId(criteria.surveyId)
-        
-        // 검색 조건이 없으면 페이징 적용하여 반환
-        if (criteria.questionTitle == null && criteria.answerValue == null) {
-            val start = pageable.pageNumber * pageable.pageSize
-            val end = minOf(start + pageable.pageSize, allResponses.size)
-            val pageContent = if (start < allResponses.size) {
-                allResponses.subList(start, end)
-            } else {
-                emptyList()
-            }
-            return PageImpl(pageContent, pageable, allResponses.size.toLong())
-        }
-        
-        // 필터링
-        val filteredResponses = allResponses.filter { response ->
-            response.answers.any { answer ->
-                val matchesQuestionTitle = criteria.questionTitle?.let {
-                    answer.questionTitle.contains(it, ignoreCase = true)
-                } ?: true
-                
-                val matchesAnswerValue = criteria.answerValue?.let { searchValue ->
-                    // 텍스트 응답 검색
-                    val matchesText = answer.textValue?.contains(searchValue, ignoreCase = true) ?: false
-                    // 선택지 텍스트 검색
-                    val matchesChoice = answer.selectedChoiceTexts.any { choiceText ->
-                        choiceText.contains(searchValue, ignoreCase = true)
-                    }
-                    matchesText || matchesChoice
-                } ?: true
-                
-                matchesQuestionTitle && matchesAnswerValue
-            }
-        }
-        
-        // 페이징 적용
-        val start = pageable.pageNumber * pageable.pageSize
-        val end = minOf(start + pageable.pageSize, filteredResponses.size)
-        val pageContent = if (start < filteredResponses.size) {
-            filteredResponses.subList(start, end)
-        } else {
-            emptyList()
-        }
-        
-        return PageImpl(pageContent, pageable, filteredResponses.size.toLong())
+        // 쿼리 레벨에서 필터링하여 조회
+        return responseRepository.searchResponsesByCriteria(criteria, pageable)
     }
 
     private fun validateAnswersAgainstSurvey(
@@ -227,10 +182,11 @@ class ResponseService(
                 }
 
                 // 선택된 선택지의 텍스트 수집
-                val selectedChoiceTexts = question.choices
-                    .filter { it.id in selectedChoiceIds }
-                    .map { it.text }
-                    .toSet()
+                val selectedChoiceTexts =
+                    question.choices
+                        .filter { it.id in selectedChoiceIds }
+                        .map { it.text }
+                        .toSet()
 
                 Answer.createChoiceAnswer(
                     questionId = question.id,

--- a/project/hajin-onboarding/src/main/kotlin/com/innercircle/survey/response/domain/Answer.kt
+++ b/project/hajin-onboarding/src/main/kotlin/com/innercircle/survey/response/domain/Answer.kt
@@ -52,25 +52,27 @@ class Answer private constructor(
     fun validateAnswer() {
         when (questionType) {
             QuestionType.SHORT_TEXT -> {
-                val text = textValue
-                    ?: throw InvalidAnswerException("단답형 질문에는 텍스트 응답이 필요합니다.")
-                
+                val text =
+                    textValue
+                        ?: throw InvalidAnswerException("단답형 질문에는 텍스트 응답이 필요합니다.")
+
                 if (text.length > MAX_SHORT_TEXT_LENGTH) {
                     throw TextTooLongException(MAX_SHORT_TEXT_LENGTH, text.length)
                 }
-                
+
                 if (selectedChoiceIds.isNotEmpty()) {
                     throw InvalidAnswerException("텍스트형 질문에는 선택지를 선택할 수 없습니다.")
                 }
             }
             QuestionType.LONG_TEXT -> {
-                val text = textValue
-                    ?: throw InvalidAnswerException("장문형 질문에는 텍스트 응답이 필요합니다.")
-                
+                val text =
+                    textValue
+                        ?: throw InvalidAnswerException("장문형 질문에는 텍스트 응답이 필요합니다.")
+
                 if (text.length > MAX_LONG_TEXT_LENGTH) {
                     throw TextTooLongException(MAX_LONG_TEXT_LENGTH, text.length)
                 }
-                
+
                 if (selectedChoiceIds.isNotEmpty()) {
                     throw InvalidAnswerException("텍스트형 질문에는 선택지를 선택할 수 없습니다.")
                 }
@@ -107,8 +109,8 @@ class Answer private constructor(
             questionType: QuestionType,
             textValue: String,
         ): Answer {
-            require(questionType.isTextType()) { 
-                "텍스트 응답은 텍스트형 질문에만 가능합니다." 
+            require(questionType.isTextType()) {
+                "텍스트 응답은 텍스트형 질문에만 가능합니다."
             }
 
             val answer =
@@ -129,8 +131,8 @@ class Answer private constructor(
             selectedChoiceIds: Set<UUID>,
             selectedChoiceTexts: Set<String> = emptySet(),
         ): Answer {
-            require(questionType.isChoiceType()) { 
-                "선택지 응답은 선택형 질문에만 가능합니다." 
+            require(questionType.isChoiceType()) {
+                "선택지 응답은 선택형 질문에만 가능합니다."
             }
 
             val answer =

--- a/project/hajin-onboarding/src/main/kotlin/com/innercircle/survey/response/domain/Answer.kt
+++ b/project/hajin-onboarding/src/main/kotlin/com/innercircle/survey/response/domain/Answer.kt
@@ -36,6 +36,13 @@ class Answer private constructor(
     )
     @Column(name = "choice_id")
     val selectedChoiceIds: MutableSet<UUID> = mutableSetOf(),
+    @ElementCollection
+    @CollectionTable(
+        name = "ANSWER_CHOICE_TEXTS",
+        joinColumns = [JoinColumn(name = "answer_id")],
+    )
+    @Column(name = "choice_text")
+    val selectedChoiceTexts: MutableSet<String> = mutableSetOf(),
 ) : BaseEntity() {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "response_id")
@@ -120,6 +127,7 @@ class Answer private constructor(
             questionTitle: String,
             questionType: QuestionType,
             selectedChoiceIds: Set<UUID>,
+            selectedChoiceTexts: Set<String> = emptySet(),
         ): Answer {
             require(questionType.isChoiceType()) { 
                 "선택지 응답은 선택형 질문에만 가능합니다." 
@@ -132,6 +140,7 @@ class Answer private constructor(
                     questionType = questionType,
                 )
             answer.selectedChoiceIds.addAll(selectedChoiceIds)
+            answer.selectedChoiceTexts.addAll(selectedChoiceTexts)
             answer.validateAnswer()
             return answer
         }

--- a/project/hajin-onboarding/src/main/kotlin/com/innercircle/survey/survey/domain/Question.kt
+++ b/project/hajin-onboarding/src/main/kotlin/com/innercircle/survey/survey/domain/Question.kt
@@ -97,7 +97,7 @@ class Question private constructor(
         require(type.isChoiceType()) {
             "${type.description} 타입은 선택지를 가질 수 없습니다."
         }
-        
+
         if (!canAddMoreChoices()) {
             throw SurveyChoiceLimitExceededException(_choices.size + 1, MAX_CHOICES)
         }

--- a/project/hajin-onboarding/src/main/kotlin/com/innercircle/survey/survey/domain/Survey.kt
+++ b/project/hajin-onboarding/src/main/kotlin/com/innercircle/survey/survey/domain/Survey.kt
@@ -90,7 +90,7 @@ class Survey private constructor(
             require(description.isNotBlank()) {
                 "설문조사 설명은 필수입니다."
             }
-            
+
             if (questions.size > MAX_QUESTIONS) {
                 throw SurveyItemLimitExceededException(questions.size, MAX_QUESTIONS)
             }

--- a/project/hajin-onboarding/src/test/kotlin/com/innercircle/survey/response/ResponseSearchIntegrationTest.kt
+++ b/project/hajin-onboarding/src/test/kotlin/com/innercircle/survey/response/ResponseSearchIntegrationTest.kt
@@ -1,0 +1,209 @@
+package com.innercircle.survey.response
+
+import com.innercircle.survey.response.adapter.`in`.web.dto.SubmitResponseRequest
+import com.innercircle.survey.survey.adapter.`in`.web.dto.CreateSurveyRequest
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+import io.restassured.RestAssured
+import io.restassured.http.ContentType
+import org.hamcrest.Matchers.`is`
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.boot.test.web.server.LocalServerPort
+import org.springframework.test.context.ActiveProfiles
+import java.util.UUID
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@ActiveProfiles("test")
+class ResponseSearchIntegrationTest(
+    @LocalServerPort private val port: Int,
+) : DescribeSpec({
+    beforeSpec {
+        RestAssured.port = port
+    }
+
+    describe("설문조사 응답 검색 API") {
+        lateinit var surveyId: String
+
+        beforeTest {
+            // 설문조사 생성
+            val createSurveyRequest = CreateSurveyRequest(
+                title = "검색 테스트 설문조사",
+                description = "검색 기능 테스트를 위한 설문조사입니다.",
+                questions = listOf(
+                    CreateSurveyRequest.QuestionRequest(
+                        title = "좋아하는 프로그래밍 언어는?",
+                        description = "가장 좋아하는 프로그래밍 언어를 선택해주세요.",
+                        type = "SINGLE_CHOICE",
+                        required = true,
+                        choices = listOf("Java", "Kotlin", "Python", "JavaScript"),
+                    ),
+                    CreateSurveyRequest.QuestionRequest(
+                        title = "프로그래밍 경력",
+                        description = "프로그래밍 경력을 입력해주세요.",
+                        type = "SHORT_TEXT",
+                        required = true,
+                    ),
+                    CreateSurveyRequest.QuestionRequest(
+                        title = "사용하는 IDE",
+                        description = "주로 사용하는 IDE를 모두 선택해주세요.",
+                        type = "MULTIPLE_CHOICE",
+                        required = false,
+                        choices = listOf("IntelliJ IDEA", "VS Code", "Eclipse", "Vim"),
+                    ),
+                ),
+            )
+
+            val surveyResponse = RestAssured
+                .given()
+                .contentType(ContentType.JSON)
+                .body(createSurveyRequest)
+                .`when`()
+                .post("/api/v1/surveys")
+                .then()
+                .statusCode(201)
+                .extract()
+                .response()
+
+            surveyId = surveyResponse.jsonPath().getString("data.id")
+
+            // 여러 응답 제출
+            val questions = surveyResponse.jsonPath().getList("data.questions", Map::class.java)
+            
+            // 응답 1: Kotlin 선택, 5년 경력, IntelliJ IDEA 사용
+            submitResponse(surveyId, questions, "Kotlin", "5년", listOf("IntelliJ IDEA"))
+            
+            // 응답 2: Java 선택, 10년 경력, Eclipse와 IntelliJ IDEA 사용
+            submitResponse(surveyId, questions, "Java", "10년", listOf("Eclipse", "IntelliJ IDEA"))
+            
+            // 응답 3: Python 선택, 3년 경력, VS Code 사용
+            submitResponse(surveyId, questions, "Python", "3년", listOf("VS Code"))
+        }
+
+        context("질문 제목으로 검색할 때") {
+            it("부분 일치하는 질문의 응답들을 반환해야 한다") {
+                RestAssured
+                    .given()
+                    .queryParam("questionTitle", "프로그래밍 언어")
+                    .`when`()
+                    .get("/api/v1/surveys/$surveyId/responses")
+                    .then()
+                    .statusCode(200)
+                    .body("totalElements", `is`(3))
+                    .body("content.size()", `is`(3))
+            }
+
+            it("일치하지 않는 질문 제목으로 검색하면 빈 결과를 반환해야 한다") {
+                RestAssured
+                    .given()
+                    .queryParam("questionTitle", "존재하지 않는 질문")
+                    .`when`()
+                    .get("/api/v1/surveys/$surveyId/responses")
+                    .then()
+                    .statusCode(200)
+                    .body("totalElements", `is`(0))
+                    .body("content.size()", `is`(0))
+            }
+        }
+
+        context("응답 값으로 검색할 때") {
+            it("텍스트 응답에서 부분 일치하는 값을 찾아야 한다") {
+                RestAssured
+                    .given()
+                    .queryParam("answerValue", "5년")
+                    .`when`()
+                    .get("/api/v1/surveys/$surveyId/responses")
+                    .then()
+                    .statusCode(200)
+                    .body("totalElements", `is`(1))
+            }
+
+            it("선택지 텍스트에서 부분 일치하는 값을 찾아야 한다") {
+                RestAssured
+                    .given()
+                    .queryParam("answerValue", "IntelliJ")
+                    .`when`()
+                    .get("/api/v1/surveys/$surveyId/responses")
+                    .then()
+                    .statusCode(200)
+                    .body("totalElements", `is`(2)) // 응답 1, 2가 IntelliJ를 포함
+            }
+        }
+
+        context("질문 제목과 응답 값으로 함께 검색할 때") {
+            it("두 조건을 모두 만족하는 응답들을 반환해야 한다") {
+                RestAssured
+                    .given()
+                    .queryParam("questionTitle", "IDE")
+                    .queryParam("answerValue", "VS Code")
+                    .`when`()
+                    .get("/api/v1/surveys/$surveyId/responses")
+                    .then()
+                    .statusCode(200)
+                    .body("totalElements", `is`(1))
+            }
+        }
+
+        context("페이징과 함께 검색할 때") {
+            it("검색 결과를 페이징하여 반환해야 한다") {
+                RestAssured
+                    .given()
+                    .queryParam("answerValue", "년")
+                    .queryParam("page", 0)
+                    .queryParam("size", 2)
+                    .`when`()
+                    .get("/api/v1/surveys/$surveyId/responses")
+                    .then()
+                    .statusCode(200)
+                    .body("content.size()", `is`(2))
+                    .body("totalElements", `is`(3))
+                    .body("totalPages", `is`(2))
+            }
+        }
+    }
+})
+
+private fun submitResponse(
+    surveyId: String,
+    questions: List<Map<*, *>>,
+    language: String,
+    experience: String,
+    ides: List<String>,
+) {
+    val languageQuestion = questions.find { it["title"] == "좋아하는 프로그래밍 언어는?" }!!
+    val experienceQuestion = questions.find { it["title"] == "프로그래밍 경력" }!!
+    val ideQuestion = questions.find { it["title"] == "사용하는 IDE" }!!
+
+    val languageChoices = (languageQuestion["choices"] as List<Map<String, Any>>)
+    val languageChoice = languageChoices.find { it["text"] == language }!!
+
+    val ideChoices = (ideQuestion["choices"] as List<Map<String, Any>>)
+    val selectedIdes = ideChoices.filter { ides.contains(it["text"] as String) }
+
+    val submitRequest = SubmitResponseRequest(
+        answers = listOf(
+            SubmitResponseRequest.AnswerRequest(
+                questionId = UUID.fromString(languageQuestion["id"] as String),
+                selectedChoiceIds = setOf(UUID.fromString(languageChoice["id"] as String)),
+            ),
+            SubmitResponseRequest.AnswerRequest(
+                questionId = UUID.fromString(experienceQuestion["id"] as String),
+                textValue = experience,
+            ),
+            SubmitResponseRequest.AnswerRequest(
+                questionId = UUID.fromString(ideQuestion["id"] as String),
+                selectedChoiceIds = selectedIdes.map { UUID.fromString(it["id"] as String) }.toSet(),
+            ),
+        ),
+    )
+
+    RestAssured
+        .given()
+        .contentType(ContentType.JSON)
+        .body(submitRequest)
+        .`when`()
+        .post("/api/v1/surveys/$surveyId/responses")
+        .then()
+        .statusCode(201)
+}

--- a/project/hajin-onboarding/src/test/kotlin/com/innercircle/survey/response/ResponseSearchIntegrationTest.kt
+++ b/project/hajin-onboarding/src/test/kotlin/com/innercircle/survey/response/ResponseSearchIntegrationTest.kt
@@ -3,9 +3,6 @@ package com.innercircle.survey.response
 import com.innercircle.survey.response.adapter.`in`.web.dto.SubmitResponseRequest
 import com.innercircle.survey.survey.adapter.`in`.web.dto.CreateSurveyRequest
 import io.kotest.core.spec.style.DescribeSpec
-import io.kotest.matchers.collections.shouldHaveSize
-import io.kotest.matchers.shouldBe
-import io.kotest.matchers.string.shouldContain
 import io.restassured.RestAssured
 import io.restassured.http.ContentType
 import org.hamcrest.Matchers.`is`
@@ -19,150 +16,153 @@ import java.util.UUID
 class ResponseSearchIntegrationTest(
     @LocalServerPort private val port: Int,
 ) : DescribeSpec({
-    beforeSpec {
-        RestAssured.port = port
-    }
-
-    describe("설문조사 응답 검색 API") {
-        lateinit var surveyId: String
-
-        beforeTest {
-            // 설문조사 생성
-            val createSurveyRequest = CreateSurveyRequest(
-                title = "검색 테스트 설문조사",
-                description = "검색 기능 테스트를 위한 설문조사입니다.",
-                questions = listOf(
-                    CreateSurveyRequest.QuestionRequest(
-                        title = "좋아하는 프로그래밍 언어는?",
-                        description = "가장 좋아하는 프로그래밍 언어를 선택해주세요.",
-                        type = "SINGLE_CHOICE",
-                        required = true,
-                        choices = listOf("Java", "Kotlin", "Python", "JavaScript"),
-                    ),
-                    CreateSurveyRequest.QuestionRequest(
-                        title = "프로그래밍 경력",
-                        description = "프로그래밍 경력을 입력해주세요.",
-                        type = "SHORT_TEXT",
-                        required = true,
-                    ),
-                    CreateSurveyRequest.QuestionRequest(
-                        title = "사용하는 IDE",
-                        description = "주로 사용하는 IDE를 모두 선택해주세요.",
-                        type = "MULTIPLE_CHOICE",
-                        required = false,
-                        choices = listOf("IntelliJ IDEA", "VS Code", "Eclipse", "Vim"),
-                    ),
-                ),
-            )
-
-            val surveyResponse = RestAssured
-                .given()
-                .contentType(ContentType.JSON)
-                .body(createSurveyRequest)
-                .`when`()
-                .post("/api/v1/surveys")
-                .then()
-                .statusCode(201)
-                .extract()
-                .response()
-
-            surveyId = surveyResponse.jsonPath().getString("data.id")
-
-            // 여러 응답 제출
-            val questions = surveyResponse.jsonPath().getList("data.questions", Map::class.java)
-            
-            // 응답 1: Kotlin 선택, 5년 경력, IntelliJ IDEA 사용
-            submitResponse(surveyId, questions, "Kotlin", "5년", listOf("IntelliJ IDEA"))
-            
-            // 응답 2: Java 선택, 10년 경력, Eclipse와 IntelliJ IDEA 사용
-            submitResponse(surveyId, questions, "Java", "10년", listOf("Eclipse", "IntelliJ IDEA"))
-            
-            // 응답 3: Python 선택, 3년 경력, VS Code 사용
-            submitResponse(surveyId, questions, "Python", "3년", listOf("VS Code"))
+        beforeSpec {
+            RestAssured.port = port
         }
 
-        context("질문 제목으로 검색할 때") {
-            it("부분 일치하는 질문의 응답들을 반환해야 한다") {
-                RestAssured
-                    .given()
-                    .queryParam("questionTitle", "프로그래밍 언어")
-                    .`when`()
-                    .get("/api/v1/surveys/$surveyId/responses")
-                    .then()
-                    .statusCode(200)
-                    .body("totalElements", `is`(3))
-                    .body("content.size()", `is`(3))
+        describe("설문조사 응답 검색 API") {
+            lateinit var surveyId: String
+
+            beforeTest {
+                // 설문조사 생성
+                val createSurveyRequest =
+                    CreateSurveyRequest(
+                        title = "검색 테스트 설문조사",
+                        description = "검색 기능 테스트를 위한 설문조사입니다.",
+                        questions =
+                            listOf(
+                                CreateSurveyRequest.QuestionRequest(
+                                    title = "좋아하는 프로그래밍 언어는?",
+                                    description = "가장 좋아하는 프로그래밍 언어를 선택해주세요.",
+                                    type = "SINGLE_CHOICE",
+                                    required = true,
+                                    choices = listOf("Java", "Kotlin", "Python", "JavaScript"),
+                                ),
+                                CreateSurveyRequest.QuestionRequest(
+                                    title = "프로그래밍 경력",
+                                    description = "프로그래밍 경력을 입력해주세요.",
+                                    type = "SHORT_TEXT",
+                                    required = true,
+                                ),
+                                CreateSurveyRequest.QuestionRequest(
+                                    title = "사용하는 IDE",
+                                    description = "주로 사용하는 IDE를 모두 선택해주세요.",
+                                    type = "MULTIPLE_CHOICE",
+                                    required = false,
+                                    choices = listOf("IntelliJ IDEA", "VS Code", "Eclipse", "Vim"),
+                                ),
+                            ),
+                    )
+
+                val surveyResponse =
+                    RestAssured
+                        .given()
+                        .contentType(ContentType.JSON)
+                        .body(createSurveyRequest)
+                        .`when`()
+                        .post("/api/v1/surveys")
+                        .then()
+                        .statusCode(201)
+                        .extract()
+                        .response()
+
+                surveyId = surveyResponse.jsonPath().getString("data.id")
+
+                // 여러 응답 제출
+                val questions = surveyResponse.jsonPath().getList("data.questions", Map::class.java)
+
+                // 응답 1: Kotlin 선택, 5년 경력, IntelliJ IDEA 사용
+                submitResponse(surveyId, questions, "Kotlin", "5년", listOf("IntelliJ IDEA"))
+
+                // 응답 2: Java 선택, 10년 경력, Eclipse와 IntelliJ IDEA 사용
+                submitResponse(surveyId, questions, "Java", "10년", listOf("Eclipse", "IntelliJ IDEA"))
+
+                // 응답 3: Python 선택, 3년 경력, VS Code 사용
+                submitResponse(surveyId, questions, "Python", "3년", listOf("VS Code"))
             }
 
-            it("일치하지 않는 질문 제목으로 검색하면 빈 결과를 반환해야 한다") {
-                RestAssured
-                    .given()
-                    .queryParam("questionTitle", "존재하지 않는 질문")
-                    .`when`()
-                    .get("/api/v1/surveys/$surveyId/responses")
-                    .then()
-                    .statusCode(200)
-                    .body("totalElements", `is`(0))
-                    .body("content.size()", `is`(0))
+            context("질문 제목으로 검색할 때") {
+                it("부분 일치하는 질문의 응답들을 반환해야 한다") {
+                    RestAssured
+                        .given()
+                        .queryParam("questionTitle", "프로그래밍 언어")
+                        .`when`()
+                        .get("/api/v1/surveys/$surveyId/responses")
+                        .then()
+                        .statusCode(200)
+                        .body("totalElements", `is`(3))
+                        .body("content.size()", `is`(3))
+                }
+
+                it("일치하지 않는 질문 제목으로 검색하면 빈 결과를 반환해야 한다") {
+                    RestAssured
+                        .given()
+                        .queryParam("questionTitle", "존재하지 않는 질문")
+                        .`when`()
+                        .get("/api/v1/surveys/$surveyId/responses")
+                        .then()
+                        .statusCode(200)
+                        .body("totalElements", `is`(0))
+                        .body("content.size()", `is`(0))
+                }
+            }
+
+            context("응답 값으로 검색할 때") {
+                it("텍스트 응답에서 부분 일치하는 값을 찾아야 한다") {
+                    RestAssured
+                        .given()
+                        .queryParam("answerValue", "5년")
+                        .`when`()
+                        .get("/api/v1/surveys/$surveyId/responses")
+                        .then()
+                        .statusCode(200)
+                        .body("totalElements", `is`(1))
+                }
+
+                it("선택지 텍스트에서 부분 일치하는 값을 찾아야 한다") {
+                    RestAssured
+                        .given()
+                        .queryParam("answerValue", "IntelliJ")
+                        .`when`()
+                        .get("/api/v1/surveys/$surveyId/responses")
+                        .then()
+                        .statusCode(200)
+                        .body("totalElements", `is`(2)) // 응답 1, 2가 IntelliJ를 포함
+                }
+            }
+
+            context("질문 제목과 응답 값으로 함께 검색할 때") {
+                it("두 조건을 모두 만족하는 응답들을 반환해야 한다") {
+                    RestAssured
+                        .given()
+                        .queryParam("questionTitle", "IDE")
+                        .queryParam("answerValue", "VS Code")
+                        .`when`()
+                        .get("/api/v1/surveys/$surveyId/responses")
+                        .then()
+                        .statusCode(200)
+                        .body("totalElements", `is`(1))
+                }
+            }
+
+            context("페이징과 함께 검색할 때") {
+                it("검색 결과를 페이징하여 반환해야 한다") {
+                    RestAssured
+                        .given()
+                        .queryParam("answerValue", "년")
+                        .queryParam("page", 0)
+                        .queryParam("size", 2)
+                        .`when`()
+                        .get("/api/v1/surveys/$surveyId/responses")
+                        .then()
+                        .statusCode(200)
+                        .body("content.size()", `is`(2))
+                        .body("totalElements", `is`(3))
+                        .body("totalPages", `is`(2))
+                }
             }
         }
-
-        context("응답 값으로 검색할 때") {
-            it("텍스트 응답에서 부분 일치하는 값을 찾아야 한다") {
-                RestAssured
-                    .given()
-                    .queryParam("answerValue", "5년")
-                    .`when`()
-                    .get("/api/v1/surveys/$surveyId/responses")
-                    .then()
-                    .statusCode(200)
-                    .body("totalElements", `is`(1))
-            }
-
-            it("선택지 텍스트에서 부분 일치하는 값을 찾아야 한다") {
-                RestAssured
-                    .given()
-                    .queryParam("answerValue", "IntelliJ")
-                    .`when`()
-                    .get("/api/v1/surveys/$surveyId/responses")
-                    .then()
-                    .statusCode(200)
-                    .body("totalElements", `is`(2)) // 응답 1, 2가 IntelliJ를 포함
-            }
-        }
-
-        context("질문 제목과 응답 값으로 함께 검색할 때") {
-            it("두 조건을 모두 만족하는 응답들을 반환해야 한다") {
-                RestAssured
-                    .given()
-                    .queryParam("questionTitle", "IDE")
-                    .queryParam("answerValue", "VS Code")
-                    .`when`()
-                    .get("/api/v1/surveys/$surveyId/responses")
-                    .then()
-                    .statusCode(200)
-                    .body("totalElements", `is`(1))
-            }
-        }
-
-        context("페이징과 함께 검색할 때") {
-            it("검색 결과를 페이징하여 반환해야 한다") {
-                RestAssured
-                    .given()
-                    .queryParam("answerValue", "년")
-                    .queryParam("page", 0)
-                    .queryParam("size", 2)
-                    .`when`()
-                    .get("/api/v1/surveys/$surveyId/responses")
-                    .then()
-                    .statusCode(200)
-                    .body("content.size()", `is`(2))
-                    .body("totalElements", `is`(3))
-                    .body("totalPages", `is`(2))
-            }
-        }
-    }
-})
+    })
 
 private fun submitResponse(
     surveyId: String,
@@ -181,22 +181,24 @@ private fun submitResponse(
     val ideChoices = (ideQuestion["choices"] as List<Map<String, Any>>)
     val selectedIdes = ideChoices.filter { ides.contains(it["text"] as String) }
 
-    val submitRequest = SubmitResponseRequest(
-        answers = listOf(
-            SubmitResponseRequest.AnswerRequest(
-                questionId = UUID.fromString(languageQuestion["id"] as String),
-                selectedChoiceIds = setOf(UUID.fromString(languageChoice["id"] as String)),
-            ),
-            SubmitResponseRequest.AnswerRequest(
-                questionId = UUID.fromString(experienceQuestion["id"] as String),
-                textValue = experience,
-            ),
-            SubmitResponseRequest.AnswerRequest(
-                questionId = UUID.fromString(ideQuestion["id"] as String),
-                selectedChoiceIds = selectedIdes.map { UUID.fromString(it["id"] as String) }.toSet(),
-            ),
-        ),
-    )
+    val submitRequest =
+        SubmitResponseRequest(
+            answers =
+                listOf(
+                    SubmitResponseRequest.AnswerRequest(
+                        questionId = UUID.fromString(languageQuestion["id"] as String),
+                        selectedChoiceIds = setOf(UUID.fromString(languageChoice["id"] as String)),
+                    ),
+                    SubmitResponseRequest.AnswerRequest(
+                        questionId = UUID.fromString(experienceQuestion["id"] as String),
+                        textValue = experience,
+                    ),
+                    SubmitResponseRequest.AnswerRequest(
+                        questionId = UUID.fromString(ideQuestion["id"] as String),
+                        selectedChoiceIds = selectedIdes.map { UUID.fromString(it["id"] as String) }.toSet(),
+                    ),
+                ),
+        )
 
     RestAssured
         .given()

--- a/project/hajin-onboarding/src/test/kotlin/com/innercircle/survey/response/adapter/in/web/ResponseControllerTest.kt
+++ b/project/hajin-onboarding/src/test/kotlin/com/innercircle/survey/response/adapter/in/web/ResponseControllerTest.kt
@@ -321,10 +321,11 @@ class ResponseControllerTest(
                             idField.set(this, surveyId)
                         }
 
-                    val mockResponses = listOf(
-                        Response.create(survey = mockSurvey, respondentId = "user1"),
-                        Response.create(survey = mockSurvey, respondentId = "user2")
-                    )
+                    val mockResponses =
+                        listOf(
+                            Response.create(survey = mockSurvey, respondentId = "user1"),
+                            Response.create(survey = mockSurvey, respondentId = "user2"),
+                        )
                     mockResponses.forEach { response ->
                         val baseClass = response::class.java.superclass
                         val idField = baseClass.getDeclaredField("id")
@@ -358,24 +359,25 @@ class ResponseControllerTest(
                 it("200 OK와 함께 응답 요약 목록을 반환해야 한다") {
                     // given
                     val pageable = PageRequest.of(0, 10)
-                    val mockSummaries = listOf(
-                        ResponseSummaryProjection(
-                            id = UUID.randomUUID(),
-                            surveyId = surveyId,
-                            surveyVersion = 1,
-                            respondentId = "user1",
-                            createdAt = LocalDateTime.now(),
-                            answerCount = 5
-                        ),
-                        ResponseSummaryProjection(
-                            id = UUID.randomUUID(),
-                            surveyId = surveyId,
-                            surveyVersion = 1,
-                            respondentId = "user2",
-                            createdAt = LocalDateTime.now(),
-                            answerCount = 3
+                    val mockSummaries =
+                        listOf(
+                            ResponseSummaryProjection(
+                                id = UUID.randomUUID(),
+                                surveyId = surveyId,
+                                surveyVersion = 1,
+                                respondentId = "user1",
+                                createdAt = LocalDateTime.now(),
+                                answerCount = 5,
+                            ),
+                            ResponseSummaryProjection(
+                                id = UUID.randomUUID(),
+                                surveyId = surveyId,
+                                surveyVersion = 1,
+                                respondentId = "user2",
+                                createdAt = LocalDateTime.now(),
+                                answerCount = 3,
+                            ),
                         )
-                    )
                     val page = PageImpl(mockSummaries, pageable, 2)
                     every { responseUseCase.getResponseSummariesBySurveyId(surveyId, any()) } returns page
 
@@ -397,8 +399,12 @@ class ResponseControllerTest(
             context("존재하지 않는 설문조사 ID로 조회") {
                 it("404 Not Found를 반환해야 한다") {
                     // given
-                    every { responseUseCase.getResponsesBySurveyId(surveyId, any()) } throws 
-                        SurveyNotFoundException(surveyId)
+                    every {
+                        responseUseCase.getResponsesBySurveyId(
+                            surveyId,
+                            any(),
+                        )
+                    } throws SurveyNotFoundException(surveyId)
 
                     // when & then
                     RestAssured.given()

--- a/project/hajin-onboarding/src/test/kotlin/com/innercircle/survey/response/application/service/ResponseServiceTest.kt
+++ b/project/hajin-onboarding/src/test/kotlin/com/innercircle/survey/response/application/service/ResponseServiceTest.kt
@@ -10,7 +10,6 @@ import com.innercircle.survey.survey.domain.exception.SurveyNotFoundException
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.DescribeSpec
 import io.kotest.matchers.shouldBe
-import io.kotest.matchers.shouldNotBe
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
@@ -28,14 +27,16 @@ class ResponseServiceTest : DescribeSpec({
 
             context("존재하는 응답 ID가 주어졌을 때") {
                 val responseId = UUID.randomUUID()
-                val mockSurvey = mockk<Survey> {
-                    every { id } returns UUID.randomUUID()
-                    every { title } returns "Test Survey"
-                }
-                val mockResponse = mockk<Response> {
-                    every { id } returns responseId
-                    every { survey } returns mockSurvey
-                }
+                val mockSurvey =
+                    mockk<Survey> {
+                        every { id } returns UUID.randomUUID()
+                        every { title } returns "Test Survey"
+                    }
+                val mockResponse =
+                    mockk<Response> {
+                        every { id } returns responseId
+                        every { survey } returns mockSurvey
+                    }
 
                 it("응답을 반환해야 한다") {
                     every { responseRepository.findById(responseId) } returns mockResponse
@@ -65,16 +66,18 @@ class ResponseServiceTest : DescribeSpec({
                 val responseRepository = mockk<ResponseRepository>()
                 val surveyRepository = mockk<SurveyRepository>()
                 val service = ResponseService(responseRepository, surveyRepository)
-                
+
                 val surveyId = UUID.randomUUID()
                 val pageable = PageRequest.of(0, 10)
-                val mockSurvey = mockk<Survey> {
-                    every { id } returns surveyId
-                }
-                val mockResponses = listOf(
-                    mockk<Response>(),
-                    mockk<Response>()
-                )
+                val mockSurvey =
+                    mockk<Survey> {
+                        every { id } returns surveyId
+                    }
+                val mockResponses =
+                    listOf(
+                        mockk<Response>(),
+                        mockk<Response>(),
+                    )
                 val page = PageImpl(mockResponses, pageable, 2)
 
                 it("페이징된 응답 목록을 반환해야 한다") {
@@ -94,7 +97,7 @@ class ResponseServiceTest : DescribeSpec({
                 val responseRepository = mockk<ResponseRepository>(relaxed = true)
                 val surveyRepository = mockk<SurveyRepository>()
                 val service = ResponseService(responseRepository, surveyRepository)
-                
+
                 val surveyId = UUID.randomUUID()
                 val pageable = PageRequest.of(0, 10)
 
@@ -119,27 +122,29 @@ class ResponseServiceTest : DescribeSpec({
             context("존재하는 설문조사 ID로 요약 조회할 때") {
                 val surveyId = UUID.randomUUID()
                 val pageable = PageRequest.of(0, 10)
-                val mockSurvey = mockk<Survey> {
-                    every { id } returns surveyId
-                }
-                val mockSummaries = listOf(
-                    ResponseSummaryProjection(
-                        id = UUID.randomUUID(),
-                        surveyId = surveyId,
-                        surveyVersion = 1,
-                        respondentId = "user1",
-                        createdAt = LocalDateTime.now(),
-                        answerCount = 5
-                    ),
-                    ResponseSummaryProjection(
-                        id = UUID.randomUUID(),
-                        surveyId = surveyId,
-                        surveyVersion = 1,
-                        respondentId = "user2",
-                        createdAt = LocalDateTime.now(),
-                        answerCount = 3
+                val mockSurvey =
+                    mockk<Survey> {
+                        every { id } returns surveyId
+                    }
+                val mockSummaries =
+                    listOf(
+                        ResponseSummaryProjection(
+                            id = UUID.randomUUID(),
+                            surveyId = surveyId,
+                            surveyVersion = 1,
+                            respondentId = "user1",
+                            createdAt = LocalDateTime.now(),
+                            answerCount = 5,
+                        ),
+                        ResponseSummaryProjection(
+                            id = UUID.randomUUID(),
+                            surveyId = surveyId,
+                            surveyVersion = 1,
+                            respondentId = "user2",
+                            createdAt = LocalDateTime.now(),
+                            answerCount = 3,
+                        ),
                     )
-                )
                 val page = PageImpl(mockSummaries, pageable, 2)
 
                 it("페이징된 응답 요약 목록을 반환해야 한다") {

--- a/project/hajin-onboarding/src/test/kotlin/com/innercircle/survey/survey/ResponsePreservationTest.kt
+++ b/project/hajin-onboarding/src/test/kotlin/com/innercircle/survey/survey/ResponsePreservationTest.kt
@@ -1,0 +1,185 @@
+package com.innercircle.survey.survey
+
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import io.restassured.RestAssured
+import io.restassured.http.ContentType
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.boot.test.web.server.LocalServerPort
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+class ResponsePreservationTest(
+    @LocalServerPort private val port: Int,
+) : DescribeSpec({
+
+    beforeSpec {
+        RestAssured.port = port
+    }
+
+    describe("기존 응답 유지 기본 테스트") {
+        it("설문조사 수정 전후 응답 버전이 유지되어야 한다") {
+            // 1. 설문조사 생성
+            val createRequest = """
+                {
+                    "title": "테스트 설문",
+                    "description": "설명",
+                    "questions": [
+                        {
+                            "title": "질문",
+                            "description": "설명",
+                            "type": "SHORT_TEXT",
+                            "required": true
+                        }
+                    ]
+                }
+            """.trimIndent()
+
+            val survey = RestAssured.given()
+                .contentType(ContentType.JSON)
+                .body(createRequest)
+                .`when`()
+                .post("/api/v1/surveys")
+                .then()
+                .statusCode(201)
+                .extract()
+                .jsonPath()
+
+            val surveyId = survey.getString("data.id")
+            val questionId = survey.getString("data.questions[0].id")
+            val version1 = survey.getInt("data.version")
+
+            println("Created survey $surveyId with version $version1")
+
+            // 2. 응답 제출
+            val responseRequest = """
+                {
+                    "answers": [
+                        {
+                            "questionId": "$questionId",
+                            "textValue": "첫 번째 응답"
+                        }
+                    ]
+                }
+            """.trimIndent()
+
+            val response = RestAssured.given()
+                .contentType(ContentType.JSON)
+                .body(responseRequest)
+                .`when`()
+                .post("/api/v1/surveys/$surveyId/responses")
+                .then()
+                .statusCode(201)
+                .extract()
+                .jsonPath()
+
+            val responseId = response.getString("data.id")
+            val responseSurveyVersion = response.getInt("data.surveyVersion")
+
+            responseSurveyVersion shouldBe version1
+            println("Created response $responseId with survey version $responseSurveyVersion")
+
+            // 3. 설문조사 수정
+            val updateRequest = """
+                {
+                    "title": "수정된 설문",
+                    "description": "수정된 설명",
+                    "questions": [
+                        {
+                            "title": "새 질문",
+                            "description": "새 설명",
+                            "type": "LONG_TEXT",
+                            "required": false
+                        }
+                    ]
+                }
+            """.trimIndent()
+
+            val updatedSurvey = RestAssured.given()
+                .contentType(ContentType.JSON)
+                .body(updateRequest)
+                .`when`()
+                .put("/api/v1/surveys/$surveyId")
+                .then()
+                .statusCode(200)
+                .extract()
+                .jsonPath()
+
+            val version2 = updatedSurvey.getInt("data.version")
+            version2 shouldNotBe version1
+            println("Updated survey to version $version2")
+
+            // 4. 기존 응답 조회
+            val checkResponse = RestAssured.given()
+                .`when`()
+                .get("/api/v1/responses/$responseId")
+                .then()
+                .extract()
+
+            println("Response status: ${checkResponse.statusCode()}")
+            
+            if (checkResponse.statusCode() == 200) {
+                val responseJson = checkResponse.jsonPath()
+                val checkVersion = responseJson.getInt("data.surveyVersion")
+                checkVersion shouldBe version1
+                println("✅ Response still has original version $checkVersion")
+            } else {
+                println("❌ Failed to retrieve response: ${checkResponse.body().asString()}")
+            }
+
+            // 5. 설문조사별 응답 목록 조회 (대안)
+            val allResponses = RestAssured.given()
+                .`when`()
+                .get("/api/v1/surveys/$surveyId/responses")
+                .then()
+                .statusCode(200)
+                .extract()
+                .jsonPath()
+
+            val responsesList = allResponses.getList<Map<String, Any>>("content")
+            responsesList.size shouldBe 1
+            
+            val firstResponse = responsesList[0]
+            val listVersion = firstResponse["surveyVersion"] as Int
+            listVersion shouldBe version1
+            println("✅ Response in list also has original version $listVersion")
+        }
+
+        it("다중 선택 질문의 선택지가 올바르게 저장되어야 한다") {
+            val createRequest = """
+                {
+                    "title": "선택지 테스트",
+                    "description": "선택지 저장 확인",
+                    "questions": [
+                        {
+                            "title": "좋아하는 언어",
+                            "description": "모두 선택",
+                            "type": "MULTIPLE_CHOICE",
+                            "required": true,
+                            "choices": ["Java", "Kotlin", "Python", "JavaScript", "Go"]
+                        }
+                    ]
+                }
+            """.trimIndent()
+
+            val survey = RestAssured.given()
+                .contentType(ContentType.JSON)
+                .body(createRequest)
+                .`when`()
+                .post("/api/v1/surveys")
+                .then()
+                .statusCode(201)
+                .extract()
+                .jsonPath()
+
+            // 선택지 확인
+            val choices = survey.getList<Map<String, Any>>("data.questions[0].choices")
+            choices.size shouldBe 5
+            
+            val choiceTexts = choices.map { it["text"] as String }
+            choiceTexts shouldBe listOf("Java", "Kotlin", "Python", "JavaScript", "Go")
+            
+            println("✅ All choices saved correctly: $choiceTexts")
+        }
+    }
+})

--- a/project/hajin-onboarding/src/test/kotlin/com/innercircle/survey/survey/ResponsePreservationTest.kt
+++ b/project/hajin-onboarding/src/test/kotlin/com/innercircle/survey/survey/ResponsePreservationTest.kt
@@ -13,173 +13,183 @@ class ResponsePreservationTest(
     @LocalServerPort private val port: Int,
 ) : DescribeSpec({
 
-    beforeSpec {
-        RestAssured.port = port
-    }
+        beforeSpec {
+            RestAssured.port = port
+        }
 
-    describe("기존 응답 유지 기본 테스트") {
-        it("설문조사 수정 전후 응답 버전이 유지되어야 한다") {
-            // 1. 설문조사 생성
-            val createRequest = """
-                {
-                    "title": "테스트 설문",
-                    "description": "설명",
-                    "questions": [
-                        {
-                            "title": "질문",
-                            "description": "설명",
-                            "type": "SHORT_TEXT",
-                            "required": true
-                        }
-                    ]
+        describe("기존 응답 유지 기본 테스트") {
+            it("설문조사 수정 전후 응답 버전이 유지되어야 한다") {
+                // 1. 설문조사 생성
+                val createRequest =
+                    """
+                    {
+                        "title": "테스트 설문",
+                        "description": "설명",
+                        "questions": [
+                            {
+                                "title": "질문",
+                                "description": "설명",
+                                "type": "SHORT_TEXT",
+                                "required": true
+                            }
+                        ]
+                    }
+                    """.trimIndent()
+
+                val survey =
+                    RestAssured.given()
+                        .contentType(ContentType.JSON)
+                        .body(createRequest)
+                        .`when`()
+                        .post("/api/v1/surveys")
+                        .then()
+                        .statusCode(201)
+                        .extract()
+                        .jsonPath()
+
+                val surveyId = survey.getString("data.id")
+                val questionId = survey.getString("data.questions[0].id")
+                val version1 = survey.getInt("data.version")
+
+                println("Created survey $surveyId with version $version1")
+
+                // 2. 응답 제출
+                val responseRequest =
+                    """
+                    {
+                        "answers": [
+                            {
+                                "questionId": "$questionId",
+                                "textValue": "첫 번째 응답"
+                            }
+                        ]
+                    }
+                    """.trimIndent()
+
+                val response =
+                    RestAssured.given()
+                        .contentType(ContentType.JSON)
+                        .body(responseRequest)
+                        .`when`()
+                        .post("/api/v1/surveys/$surveyId/responses")
+                        .then()
+                        .statusCode(201)
+                        .extract()
+                        .jsonPath()
+
+                val responseId = response.getString("data.id")
+                val responseSurveyVersion = response.getInt("data.surveyVersion")
+
+                responseSurveyVersion shouldBe version1
+                println("Created response $responseId with survey version $responseSurveyVersion")
+
+                // 3. 설문조사 수정
+                val updateRequest =
+                    """
+                    {
+                        "title": "수정된 설문",
+                        "description": "수정된 설명",
+                        "questions": [
+                            {
+                                "title": "새 질문",
+                                "description": "새 설명",
+                                "type": "LONG_TEXT",
+                                "required": false
+                            }
+                        ]
+                    }
+                    """.trimIndent()
+
+                val updatedSurvey =
+                    RestAssured.given()
+                        .contentType(ContentType.JSON)
+                        .body(updateRequest)
+                        .`when`()
+                        .put("/api/v1/surveys/$surveyId")
+                        .then()
+                        .statusCode(200)
+                        .extract()
+                        .jsonPath()
+
+                val version2 = updatedSurvey.getInt("data.version")
+                version2 shouldNotBe version1
+                println("Updated survey to version $version2")
+
+                // 4. 기존 응답 조회
+                val checkResponse =
+                    RestAssured.given()
+                        .`when`()
+                        .get("/api/v1/responses/$responseId")
+                        .then()
+                        .extract()
+
+                println("Response status: ${checkResponse.statusCode()}")
+
+                if (checkResponse.statusCode() == 200) {
+                    val responseJson = checkResponse.jsonPath()
+                    val checkVersion = responseJson.getInt("data.surveyVersion")
+                    checkVersion shouldBe version1
+                    println("✅ Response still has original version $checkVersion")
+                } else {
+                    println("❌ Failed to retrieve response: ${checkResponse.body().asString()}")
                 }
-            """.trimIndent()
 
-            val survey = RestAssured.given()
-                .contentType(ContentType.JSON)
-                .body(createRequest)
-                .`when`()
-                .post("/api/v1/surveys")
-                .then()
-                .statusCode(201)
-                .extract()
-                .jsonPath()
+                // 5. 설문조사별 응답 목록 조회 (대안)
+                val allResponses =
+                    RestAssured.given()
+                        .`when`()
+                        .get("/api/v1/surveys/$surveyId/responses")
+                        .then()
+                        .statusCode(200)
+                        .extract()
+                        .jsonPath()
 
-            val surveyId = survey.getString("data.id")
-            val questionId = survey.getString("data.questions[0].id")
-            val version1 = survey.getInt("data.version")
+                val responsesList = allResponses.getList<Map<String, Any>>("content")
+                responsesList.size shouldBe 1
 
-            println("Created survey $surveyId with version $version1")
-
-            // 2. 응답 제출
-            val responseRequest = """
-                {
-                    "answers": [
-                        {
-                            "questionId": "$questionId",
-                            "textValue": "첫 번째 응답"
-                        }
-                    ]
-                }
-            """.trimIndent()
-
-            val response = RestAssured.given()
-                .contentType(ContentType.JSON)
-                .body(responseRequest)
-                .`when`()
-                .post("/api/v1/surveys/$surveyId/responses")
-                .then()
-                .statusCode(201)
-                .extract()
-                .jsonPath()
-
-            val responseId = response.getString("data.id")
-            val responseSurveyVersion = response.getInt("data.surveyVersion")
-
-            responseSurveyVersion shouldBe version1
-            println("Created response $responseId with survey version $responseSurveyVersion")
-
-            // 3. 설문조사 수정
-            val updateRequest = """
-                {
-                    "title": "수정된 설문",
-                    "description": "수정된 설명",
-                    "questions": [
-                        {
-                            "title": "새 질문",
-                            "description": "새 설명",
-                            "type": "LONG_TEXT",
-                            "required": false
-                        }
-                    ]
-                }
-            """.trimIndent()
-
-            val updatedSurvey = RestAssured.given()
-                .contentType(ContentType.JSON)
-                .body(updateRequest)
-                .`when`()
-                .put("/api/v1/surveys/$surveyId")
-                .then()
-                .statusCode(200)
-                .extract()
-                .jsonPath()
-
-            val version2 = updatedSurvey.getInt("data.version")
-            version2 shouldNotBe version1
-            println("Updated survey to version $version2")
-
-            // 4. 기존 응답 조회
-            val checkResponse = RestAssured.given()
-                .`when`()
-                .get("/api/v1/responses/$responseId")
-                .then()
-                .extract()
-
-            println("Response status: ${checkResponse.statusCode()}")
-            
-            if (checkResponse.statusCode() == 200) {
-                val responseJson = checkResponse.jsonPath()
-                val checkVersion = responseJson.getInt("data.surveyVersion")
-                checkVersion shouldBe version1
-                println("✅ Response still has original version $checkVersion")
-            } else {
-                println("❌ Failed to retrieve response: ${checkResponse.body().asString()}")
+                val firstResponse = responsesList[0]
+                val listVersion = firstResponse["surveyVersion"] as Int
+                listVersion shouldBe version1
+                println("✅ Response in list also has original version $listVersion")
             }
 
-            // 5. 설문조사별 응답 목록 조회 (대안)
-            val allResponses = RestAssured.given()
-                .`when`()
-                .get("/api/v1/surveys/$surveyId/responses")
-                .then()
-                .statusCode(200)
-                .extract()
-                .jsonPath()
+            it("다중 선택 질문의 선택지가 올바르게 저장되어야 한다") {
+                val createRequest =
+                    """
+                    {
+                        "title": "선택지 테스트",
+                        "description": "선택지 저장 확인",
+                        "questions": [
+                            {
+                                "title": "좋아하는 언어",
+                                "description": "모두 선택",
+                                "type": "MULTIPLE_CHOICE",
+                                "required": true,
+                                "choices": ["Java", "Kotlin", "Python", "JavaScript", "Go"]
+                            }
+                        ]
+                    }
+                    """.trimIndent()
 
-            val responsesList = allResponses.getList<Map<String, Any>>("content")
-            responsesList.size shouldBe 1
-            
-            val firstResponse = responsesList[0]
-            val listVersion = firstResponse["surveyVersion"] as Int
-            listVersion shouldBe version1
-            println("✅ Response in list also has original version $listVersion")
+                val survey =
+                    RestAssured.given()
+                        .contentType(ContentType.JSON)
+                        .body(createRequest)
+                        .`when`()
+                        .post("/api/v1/surveys")
+                        .then()
+                        .statusCode(201)
+                        .extract()
+                        .jsonPath()
+
+                // 선택지 확인
+                val choices = survey.getList<Map<String, Any>>("data.questions[0].choices")
+                choices.size shouldBe 5
+
+                val choiceTexts = choices.map { it["text"] as String }
+                choiceTexts shouldBe listOf("Java", "Kotlin", "Python", "JavaScript", "Go")
+
+                println("✅ All choices saved correctly: $choiceTexts")
+            }
         }
-
-        it("다중 선택 질문의 선택지가 올바르게 저장되어야 한다") {
-            val createRequest = """
-                {
-                    "title": "선택지 테스트",
-                    "description": "선택지 저장 확인",
-                    "questions": [
-                        {
-                            "title": "좋아하는 언어",
-                            "description": "모두 선택",
-                            "type": "MULTIPLE_CHOICE",
-                            "required": true,
-                            "choices": ["Java", "Kotlin", "Python", "JavaScript", "Go"]
-                        }
-                    ]
-                }
-            """.trimIndent()
-
-            val survey = RestAssured.given()
-                .contentType(ContentType.JSON)
-                .body(createRequest)
-                .`when`()
-                .post("/api/v1/surveys")
-                .then()
-                .statusCode(201)
-                .extract()
-                .jsonPath()
-
-            // 선택지 확인
-            val choices = survey.getList<Map<String, Any>>("data.questions[0].choices")
-            choices.size shouldBe 5
-            
-            val choiceTexts = choices.map { it["text"] as String }
-            choiceTexts shouldBe listOf("Java", "Kotlin", "Python", "JavaScript", "Go")
-            
-            println("✅ All choices saved correctly: $choiceTexts")
-        }
-    }
-})
+    })

--- a/project/hajin-onboarding/src/test/kotlin/com/innercircle/survey/survey/domain/SurveyTest.kt
+++ b/project/hajin-onboarding/src/test/kotlin/com/innercircle/survey/survey/domain/SurveyTest.kt
@@ -94,7 +94,7 @@ class SurveyTest : DescribeSpec({
                             title = "설문조사",
                             description = "설명",
                         )
-                    
+
                     val question =
                         Question.create(
                             title = "질문",
@@ -115,7 +115,7 @@ class SurveyTest : DescribeSpec({
                             title = "설문조사",
                             description = "설명",
                         )
-                    
+
                     repeat(10) {
                         survey.addQuestion(
                             Question.create(


### PR DESCRIPTION
## 변경 사항 요약

1.  **검색 기능 추가**
    * 설문 응답 항목의 이름과 응답 값을 기반으로 검색하는 기능 구현
    * 질문 제목 및 응답 내용으로 필터링 가능
2.  **도메인 변경**
    * `Answer` 엔티티에 선택지 텍스트 저장 필드 추가

---

## API 변경사항

### 1. 설문조사 응답 목록 조회 - 검색 기능 추가 (기존 API 확장)

* **Endpoint:** `GET /api/v1/surveys/{surveyId}/responses`
* **Description:** 특정 설문조사의 응답을 검색 조건에 따라 필터링하여 조회합니다.

#### Path Parameters
* `surveyId` (UUID, required): 설문조사 ID

#### Query Parameters (신규)
* `questionTitle` (String, optional): 질문 제목으로 검색 (부분 일치)
* `answerValue` (String, optional): 응답 값으로 검색 (텍스트 응답 및 선택지 텍스트 부분 일치)
* `page` (Integer, optional): 페이지 번호 (기본값: 0)
* `size` (Integer, optional): 페이지 크기 (기본값: 20)

#### Request Example
`GET /api/v1/surveys/{surveyId}/responses?questionTitle=프로그래밍&answerValue=Kotlin`

#### Response (200 OK)
```json
{
  "content": [
    {
      "id": "response-id-1",
      "surveyId": "survey-id",
      "surveyVersion": 1,
      "respondentId": "user1",
      "answers": [
        {
          "id": "answer-id-1",
          "questionId": "question-id-1",
          "questionTitle": "좋아하는 프로그래밍 언어는?",
          "questionType": "SINGLE_CHOICE",
          "textValue": null,
          "selectedChoiceIds": ["choice-id-1"]
        }
      ],
      "createdAt": "2025-06-14T10:30:00"
    }
  ],
  "pageNumber": 0,
  "pageSize": 20,
  "totalElements": 1,
  "totalPages": 1,
  "first": true,
  "last": true,
  "empty": false
}
```

## 도메인 모델 변경사항

### Answer 엔티티 (변경)

| Field                 | Type          | Description        | Constraints             | 변경 내용 |
| --------------------- | ------------- | ------------------ | ----------------------- | --------- |
| `id`                  | UUID          | 답변 ID            | PK, 자동 생성           | -         |
| `questionId`          | UUID          | 질문 ID            | Not null                | -         |
| `questionTitle`       | String        | 질문 제목          | Not null                | -         |
| `questionType`        | QuestionType  | 질문 타입          | Not null, Enum          | -         |
| `textValue`           | String        | 텍스트 응답        | Nullable, Max 5000      | -         |
| `selectedChoiceIds`   | Set<UUID>     | 선택한 선택지 ID   | ElementCollection       | -         |
| `selectedChoiceTexts` | Set<String>   | 선택한 선택지 텍스트 | ElementCollection       | 신규 추가 |

### ResponseSearchCriteria (신규)

| Field           | Type    | Description     | Constraints |
| --------------- | ------- | --------------- | ----------- |
| `surveyId`      | UUID    | 설문조사 ID     | Not null    |
| `questionTitle` | String? | 검색할 질문 제목 | Nullable    |
| `answerValue`   | String? | 검색할 응답 값   | Nullable    |

---

## 서비스 변경사항

### ResponseUseCase 인터페이스 (변경)
```kotlin
interface ResponseUseCase {
    // 기존 메서드들...

    // 신규 추가
    fun searchResponses(
        criteria: ResponseSearchCriteriacriteria,
        pageable: Pageable
    ): Page<Response>
}
```
## 구현 세부사항

### 검색 로직
* **질문 제목 검색**: 질문 제목에 검색어가 포함된 응답을 필터링
* **응답 값 검색**:
    * 텍스트 응답: `textValue` 필드에서 부분 일치 검색
    * 선택지 응답: `selectedChoiceTexts` 필드에서 부분 일치 검색
* **AND 조건**: 두 검색 조건이 모두 주어진 경우 AND 연산으로 필터링

---
## 테스트 추가
* **ResponseSearchIntegrationTest**: 검색 기능 통합 테스트
    * 질문 제목으로 검색
    * 텍스트 응답 값으로 검색
    * 선택지 텍스트로 검색
    * 복합 조건 검색
    * 페이징과 검색 동시 사용

---

## 영향 범위
* 기존 응답 조회 API와 하위 호환성 유지 (검색 파라미터는 optional)
* 선택지 텍스트 저장으로 인한 데이터 중복 저장 (검색 성능 향상을 위한 트레이드오프)