### PR TITLE
설문조사 생성 API 및 entity, exceptionHandler 생성

### DIFF
--- a/project/inguk-onboarding/build.gradle.kts
+++ b/project/inguk-onboarding/build.gradle.kts
@@ -31,7 +31,7 @@ dependencies {
 	annotationProcessor("org.projectlombok:lombok")
 
 	runtimeOnly("com.mysql:mysql-connector-j")
-
+	runtimeOnly("com.h2database:h2")
 	testImplementation("org.springframework.boot:spring-boot-starter-test")
 	implementation("org.springframework.boot:spring-boot-starter-validation")
 

--- a/project/inguk-onboarding/build.gradle.kts
+++ b/project/inguk-onboarding/build.gradle.kts
@@ -24,12 +24,17 @@ repositories {
 }
 
 dependencies {
-	//implementation("org.springframework.boot:spring-boot-starter-data-jpa")
+	implementation("org.springframework.boot:spring-boot-starter-data-jpa")
 	implementation("org.springframework.boot:spring-boot-starter-web")
+
 	compileOnly("org.projectlombok:lombok")
-	//runtimeOnly("com.mysql:mysql-connector-j")
 	annotationProcessor("org.projectlombok:lombok")
+
+	runtimeOnly("com.mysql:mysql-connector-j")
+
 	testImplementation("org.springframework.boot:spring-boot-starter-test")
+	implementation("org.springframework.boot:spring-boot-starter-validation")
+
 	testRuntimeOnly("org.junit.platform:junit-platform-launcher")
 }
 

--- a/project/inguk-onboarding/src/main/java/fastcampus/inguk_onboarding/IngukOnboardingApplication.java
+++ b/project/inguk-onboarding/src/main/java/fastcampus/inguk_onboarding/IngukOnboardingApplication.java
@@ -2,7 +2,9 @@ package fastcampus.inguk_onboarding;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
+@EnableJpaAuditing
 @SpringBootApplication
 public class IngukOnboardingApplication {
 

--- a/project/inguk-onboarding/src/main/java/fastcampus/inguk_onboarding/common/exception/ErrorCode.java
+++ b/project/inguk-onboarding/src/main/java/fastcampus/inguk_onboarding/common/exception/ErrorCode.java
@@ -1,0 +1,24 @@
+package fastcampus.inguk_onboarding.common.exception;
+
+import lombok.Getter;
+
+@Getter
+public enum ErrorCode {
+
+    INVALID_INOUT_VALUE(400, "입력값이 올바르지 않습니다."),
+    NOT_FOUND(404, "페이지를 찾을 수 없습니다."),
+    INTERNAL_ERROR(500, "서버 내부 오류가 발생했습니다."),
+
+    INVALID_SURVEY_ITEM_COUNT(2000,"설문 항목은 1개 ~ 10개까지 포함할 수 있습니다."),
+    OPTIONS_REQUIRED(2001, "선택형 항목은 선택 옵션이 필요합니다."),
+    INVALID_CHOICE_OPTION(2002, "선택 옵션이 올바르지 않습니다."),
+    DUPLICATE_SURVEY_ITEM(2003, "중복된 항목입니다.");
+
+    private final Integer code;
+    private final String message;
+
+    ErrorCode(Integer code, String message) {
+        this.code = code;
+        this.message = message;
+    }
+}

--- a/project/inguk-onboarding/src/main/java/fastcampus/inguk_onboarding/common/exception/InvalidSurveyItemCountException.java
+++ b/project/inguk-onboarding/src/main/java/fastcampus/inguk_onboarding/common/exception/InvalidSurveyItemCountException.java
@@ -1,0 +1,8 @@
+package fastcampus.inguk_onboarding.common.exception;
+
+public class InvalidSurveyItemCountException extends SurveyException {
+    
+    public InvalidSurveyItemCountException(int count) {
+        super("설문 받을 항목은 1개 ~ 10개까지 포함할 수 있습니다. 현재 항목 수: " + count);
+    }
+} 

--- a/project/inguk-onboarding/src/main/java/fastcampus/inguk_onboarding/common/exception/SurveyException.java
+++ b/project/inguk-onboarding/src/main/java/fastcampus/inguk_onboarding/common/exception/SurveyException.java
@@ -1,0 +1,13 @@
+package fastcampus.inguk_onboarding.common.exception;
+
+public class SurveyException extends RuntimeException {
+
+    public SurveyException(String message) {
+        super(message);
+    }
+
+    public SurveyException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+}

--- a/project/inguk-onboarding/src/main/java/fastcampus/inguk_onboarding/common/repository/entity/TimeBaseEntity.java
+++ b/project/inguk-onboarding/src/main/java/fastcampus/inguk_onboarding/common/repository/entity/TimeBaseEntity.java
@@ -1,0 +1,25 @@
+package fastcampus.inguk_onboarding.common.repository.entity;
+
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@EntityListeners(AuditingEntityListener.class)
+@MappedSuperclass
+@Getter
+public class TimeBaseEntity {
+
+    @CreatedDate
+    @Column(updatable = false)
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    private LocalDateTime updatedAt;
+}

--- a/project/inguk-onboarding/src/main/java/fastcampus/inguk_onboarding/common/response/ApiResponse.java
+++ b/project/inguk-onboarding/src/main/java/fastcampus/inguk_onboarding/common/response/ApiResponse.java
@@ -1,0 +1,39 @@
+package fastcampus.inguk_onboarding.common.response;
+
+public class ApiResponse<T> {
+
+    private boolean success;
+    private String message;
+    private T data;
+
+    private ApiResponse(boolean success, String message, T data) {
+        this.success = success;
+        this.message = message;
+        this.data = data;
+    }
+
+    public static <T> ApiResponse<T> success(T data) {
+        return new ApiResponse<>(true, "성공", data);
+    }
+
+    public static <T> ApiResponse<T> success(String message, T data) {
+        return new ApiResponse<>(true, message, data);
+    }
+
+    public static <T> ApiResponse<T> error(String message) {
+        return new ApiResponse<>(false, message, null);
+    }
+
+    // Getters
+    public boolean isSuccess() {
+        return success;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+
+    public T getData() {
+        return data;
+    }
+}

--- a/project/inguk-onboarding/src/main/java/fastcampus/inguk_onboarding/form/post/application/SurveyService.java
+++ b/project/inguk-onboarding/src/main/java/fastcampus/inguk_onboarding/form/post/application/SurveyService.java
@@ -1,0 +1,74 @@
+package fastcampus.inguk_onboarding.form.post.application;
+
+import fastcampus.inguk_onboarding.common.exception.InvalidSurveyItemCountException;
+import fastcampus.inguk_onboarding.form.post.application.dto.CreateSurveyItemRequestDto;
+import fastcampus.inguk_onboarding.form.post.application.dto.CreateSurveyRequestDto;
+import fastcampus.inguk_onboarding.form.post.application.dto.SurveyResponseDto;
+import fastcampus.inguk_onboarding.form.post.domain.Surveys.InputType;
+import fastcampus.inguk_onboarding.form.post.jpa.JpaSurveyRepository;
+import fastcampus.inguk_onboarding.form.post.repository.entity.post.SurveyEntity;
+import fastcampus.inguk_onboarding.form.post.repository.entity.post.SurveyItemEntity;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+public class SurveyService {
+
+    private final JpaSurveyRepository surveyRepository;
+
+    public SurveyService(JpaSurveyRepository surveyRepository) {
+        this.surveyRepository = surveyRepository;
+    }
+
+    @Transactional
+    public SurveyResponseDto createSurvey(CreateSurveyRequestDto dto) {
+        validateSurveyItemCount(dto.items().size());
+        
+        // 설문조사 엔티티 생성
+        SurveyEntity survey = new SurveyEntity(dto.name(), dto.description());
+        
+        // 각 설문 항목 처리
+        for(CreateSurveyItemRequestDto itemRequest : dto.items()) {
+            // 선택형 항목 옵션 검증
+            validateChoiceOptions(itemRequest);
+            
+            SurveyItemEntity item = new SurveyItemEntity(
+                    itemRequest.name(),
+                    itemRequest.description(),
+                    itemRequest.inputType(),
+                    itemRequest.required(),
+                    itemRequest.order()
+            );
+            
+            if (isChoiceType(itemRequest.inputType())) {
+                item.setOptions(itemRequest.options());
+            }
+            
+            // 설문조사에 항목 추가
+            survey.addItem(item);
+        }
+        
+        SurveyEntity savedSurvey = surveyRepository.save(survey);
+        return new SurveyResponseDto(savedSurvey);
+    }
+    
+    private void validateChoiceOptions(CreateSurveyItemRequestDto dto) {
+        if(isChoiceType(dto.inputType())){
+            if(dto.options() == null || dto.options().isEmpty()){
+                throw new IllegalArgumentException("선택형 항목은 선택 옵션이 필요합니다.");
+            }
+        }
+    }
+    
+    private void validateSurveyItemCount(int count) {
+        if (count < 1 || count > 10) {
+            throw new InvalidSurveyItemCountException(count);
+        }
+    }
+    
+    private boolean isChoiceType(InputType inputType) {
+        return inputType == InputType.SINGLE_TYPE || inputType == InputType.MULTIPLE_TYPE;
+    }
+
+}

--- a/project/inguk-onboarding/src/main/java/fastcampus/inguk_onboarding/form/post/application/dto/CreateSurveyItemRequestDto.java
+++ b/project/inguk-onboarding/src/main/java/fastcampus/inguk_onboarding/form/post/application/dto/CreateSurveyItemRequestDto.java
@@ -1,0 +1,28 @@
+package fastcampus.inguk_onboarding.form.post.application.dto;
+
+import fastcampus.inguk_onboarding.form.post.domain.Surveys.InputType;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+import java.util.List;
+
+public record CreateSurveyItemRequestDto(
+        @NotBlank(message = "항목 이름은 필수입니다.")
+        String name,  // title → name으로 변경
+
+        String description,
+
+        @NotNull(message = "항목 입력 형태는 필수입니다.")
+        InputType inputType,
+
+        @NotNull(message = "항목 필수 여부는 필수입니다.")
+        Boolean required,
+
+        @NotNull(message = "항목 순서는 필수입니다.")
+        Integer order,
+
+        List<String> options
+) {
+
+
+}

--- a/project/inguk-onboarding/src/main/java/fastcampus/inguk_onboarding/form/post/application/dto/CreateSurveyRequestDto.java
+++ b/project/inguk-onboarding/src/main/java/fastcampus/inguk_onboarding/form/post/application/dto/CreateSurveyRequestDto.java
@@ -1,0 +1,22 @@
+package fastcampus.inguk_onboarding.form.post.application.dto;
+
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+import java.util.List;
+
+public record CreateSurveyRequestDto(
+
+        @NotBlank(message = "설문조사 이름은 필수입니다.")
+        String name,  // title → name으로 변경
+        String description,
+        String state,  // state 필드 추가
+
+        @NotNull(message ="설문 받을 항목은 필수입니다.")
+        @Size(min=1, max=10, message="설문 받을 항목은 1개 ~ 10개 까지 포함할 수 있습니다.")
+        List<CreateSurveyItemRequestDto> items
+
+        ){
+}

--- a/project/inguk-onboarding/src/main/java/fastcampus/inguk_onboarding/form/post/application/dto/SurveyItemResponse.java
+++ b/project/inguk-onboarding/src/main/java/fastcampus/inguk_onboarding/form/post/application/dto/SurveyItemResponse.java
@@ -1,0 +1,37 @@
+package fastcampus.inguk_onboarding.form.post.application.dto;
+
+import fastcampus.inguk_onboarding.form.post.domain.Surveys.InputType;
+import fastcampus.inguk_onboarding.form.post.repository.entity.post.SurveyItemEntity;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Getter
+@Setter
+@AllArgsConstructor
+public class SurveyItemResponse {
+
+    private Long id;
+    private String title;
+    private String description;
+    private InputType inputType;
+    private Boolean required;
+    private Integer order;
+    private List<String> options;
+    public SurveyItemResponse() {}
+
+    public SurveyItemResponse(SurveyItemEntity item) {
+        this.id = item.getId();
+        this.title = item.getTitle();
+        this.description = item.getDescription();
+        this.inputType = item.getInputType();
+        this.required = item.getRequired();
+        this.order = item.getOrder();
+        this.options = item.getOptions();
+    }
+
+
+}

--- a/project/inguk-onboarding/src/main/java/fastcampus/inguk_onboarding/form/post/application/dto/SurveyResponseDto.java
+++ b/project/inguk-onboarding/src/main/java/fastcampus/inguk_onboarding/form/post/application/dto/SurveyResponseDto.java
@@ -1,0 +1,37 @@
+package fastcampus.inguk_onboarding.form.post.application.dto;
+
+import fastcampus.inguk_onboarding.form.post.repository.entity.post.SurveyEntity;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@AllArgsConstructor
+@Getter
+@Setter
+public class SurveyResponseDto {
+
+    private Long id;
+    private String title;
+    private String description;
+    private List<SurveyItemResponse> items;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+
+    public SurveyResponseDto() {}
+
+    public SurveyResponseDto(SurveyEntity survey) {
+        this.id = survey.getId();
+        this.title = survey.getTitle();
+        this.description = survey.getDescription();
+        this.items = survey.getItems().stream()
+                .map(SurveyItemResponse::new)
+                .collect(Collectors.toList());
+        this.createdAt = survey.getCreatedAt();
+        this.updatedAt = survey.getUpdatedAt();
+    }
+
+}

--- a/project/inguk-onboarding/src/main/java/fastcampus/inguk_onboarding/form/post/application/interfaces/SurveyItemRepository.java
+++ b/project/inguk-onboarding/src/main/java/fastcampus/inguk_onboarding/form/post/application/interfaces/SurveyItemRepository.java
@@ -1,0 +1,8 @@
+package fastcampus.inguk_onboarding.form.post.application.interfaces;
+
+import fastcampus.inguk_onboarding.form.post.repository.entity.post.SurveyItemEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface SurveyItemRepository  extends JpaRepository<SurveyItemEntity, Long> {
+
+}

--- a/project/inguk-onboarding/src/main/java/fastcampus/inguk_onboarding/form/post/domain/Surveys/InputType.java
+++ b/project/inguk-onboarding/src/main/java/fastcampus/inguk_onboarding/form/post/domain/Surveys/InputType.java
@@ -1,0 +1,17 @@
+package fastcampus.inguk_onboarding.form.post.domain.Surveys;
+
+public enum InputType {
+    SHORT_TYPE("단답형"),
+    LONG_TYPE("장문형"),
+    SINGLE_TYPE("단일 선택 리스트"),
+    MULTIPLE_TYPE("다중 선택 리스트");
+
+    private final String description;
+
+    InputType(String description) {
+        this.description = description;
+    }
+    public String getDescription() {
+        return description;
+    }
+}

--- a/project/inguk-onboarding/src/main/java/fastcampus/inguk_onboarding/form/post/jpa/JpaSurveyRepository.java
+++ b/project/inguk-onboarding/src/main/java/fastcampus/inguk_onboarding/form/post/jpa/JpaSurveyRepository.java
@@ -1,0 +1,23 @@
+package fastcampus.inguk_onboarding.form.post.jpa;
+
+import fastcampus.inguk_onboarding.form.post.repository.entity.post.SurveyEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.Optional;
+
+public interface JpaSurveyRepository extends JpaRepository<SurveyEntity, Long> {
+
+
+    @Modifying
+    @Query(value="UPDATE SurveyEntity p " +
+            "SET p.description = :#{#surveyEntity.getDescription()}," +
+            "p.title = :#{#surveyEntity.title()}," +
+            "p.updatedAt = now()" +
+            "WHERE p.id = :#{#surveyEntity.id} ")
+    void updateSurveyEntity(SurveyEntity surveyEntity);
+
+
+}

--- a/project/inguk-onboarding/src/main/java/fastcampus/inguk_onboarding/form/post/repository/entity/post/SurveyEntity.java
+++ b/project/inguk-onboarding/src/main/java/fastcampus/inguk_onboarding/form/post/repository/entity/post/SurveyEntity.java
@@ -1,0 +1,65 @@
+package fastcampus.inguk_onboarding.form.post.repository.entity.post;
+
+import fastcampus.inguk_onboarding.common.repository.entity.TimeBaseEntity;
+import fastcampus.inguk_onboarding.form.post.domain.Survey;
+import jakarta.persistence.*;
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Table(name="serveys")
+@Getter
+@AllArgsConstructor
+public class SurveyEntity extends TimeBaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, length = 50)
+    private String title;
+
+    @Column(length = 1000)
+    private String description;
+
+    @OneToMany(mappedBy = "survey", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
+    private List<SurveyItemEntity> items = new ArrayList<>();
+
+
+    public SurveyEntity(Survey survey) {
+        this.description = survey.getDescription();
+        this.id = survey.getId();
+        this.items = (List<SurveyItemEntity>) survey.getItem();
+        this.title = survey.getTitle();
+    }
+
+    public SurveyEntity( String title, String description) {
+       this.title = title;
+       this.description = description;
+    }
+
+
+    public void addItem(SurveyItemEntity item) {
+        items.add(item);
+        item.setSurvey(this);
+    }
+
+    public void removeItem(SurveyItemEntity item) {
+        items.remove(item);
+        item.setSurvey(null);
+    }
+
+    public Survey toSurvey() {
+        return Survey.builder()
+                .id(id)
+                .title(title)
+                .description(description)
+                .item((SurveyItemEntity) items)
+                .build();
+    }
+}

--- a/project/inguk-onboarding/src/main/java/fastcampus/inguk_onboarding/form/post/repository/entity/post/SurveyEntity.java
+++ b/project/inguk-onboarding/src/main/java/fastcampus/inguk_onboarding/form/post/repository/entity/post/SurveyEntity.java
@@ -1,9 +1,7 @@
 package fastcampus.inguk_onboarding.form.post.repository.entity.post;
 
 import fastcampus.inguk_onboarding.common.repository.entity.TimeBaseEntity;
-import fastcampus.inguk_onboarding.form.post.domain.Survey;
 import jakarta.persistence.*;
-import jakarta.validation.constraints.NotBlank;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -30,15 +28,9 @@ public class SurveyEntity extends TimeBaseEntity {
     @OneToMany(mappedBy = "survey", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
     private List<SurveyItemEntity> items = new ArrayList<>();
 
+    protected SurveyEntity() {}
 
-    public SurveyEntity(Survey survey) {
-        this.description = survey.getDescription();
-        this.id = survey.getId();
-        this.items = (List<SurveyItemEntity>) survey.getItem();
-        this.title = survey.getTitle();
-    }
-
-    public SurveyEntity( String title, String description) {
+    public SurveyEntity(String title, String description) {
        this.title = title;
        this.description = description;
     }
@@ -52,14 +44,5 @@ public class SurveyEntity extends TimeBaseEntity {
     public void removeItem(SurveyItemEntity item) {
         items.remove(item);
         item.setSurvey(null);
-    }
-
-    public Survey toSurvey() {
-        return Survey.builder()
-                .id(id)
-                .title(title)
-                .description(description)
-                .item((SurveyItemEntity) items)
-                .build();
     }
 }

--- a/project/inguk-onboarding/src/main/java/fastcampus/inguk_onboarding/form/post/repository/entity/post/SurveyItemEntity.java
+++ b/project/inguk-onboarding/src/main/java/fastcampus/inguk_onboarding/form/post/repository/entity/post/SurveyItemEntity.java
@@ -1,0 +1,63 @@
+package fastcampus.inguk_onboarding.form.post.repository.entity.post;
+
+import fastcampus.inguk_onboarding.common.repository.entity.TimeBaseEntity;
+import fastcampus.inguk_onboarding.form.post.domain.Surveys.InputType;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.util.List;
+
+@Entity
+@Table(name="survey_items")
+@Getter
+@Setter
+public class SurveyItemEntity extends TimeBaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "survey_id", nullable = false)
+    private SurveyEntity survey;
+
+    @Column(nullable = false, length = 200)
+    private String title;
+
+    @Column(length = 500)
+    private String description;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private InputType inputType;
+
+    @Column(nullable = false)
+    private Boolean required = false;
+
+    @Column(name = "item_order", nullable = false)
+    private Integer order;
+
+    @ElementCollection
+    @CollectionTable(name = "survey_item_options", joinColumns = @JoinColumn(name = "survey_item_id"))
+    @Column(name = "option_value")
+    private List<String> options;
+
+
+    protected SurveyItemEntity() {}
+
+    public SurveyItemEntity(String title, String description, InputType inputType, Boolean required, Integer order) {
+        this.title = title;
+        this.description = description;
+        this.inputType = inputType;
+        this.required = required;
+        this.order = order;
+    }
+
+    public SurveyItemEntity(List<SurveyItemEntity> items) {
+        super();
+    }
+
+    public void setSurvey(SurveyEntity survey) {
+        this.survey = survey;
+    }
+}

--- a/project/inguk-onboarding/src/main/java/fastcampus/inguk_onboarding/form/ui/SurveyController.java
+++ b/project/inguk-onboarding/src/main/java/fastcampus/inguk_onboarding/form/ui/SurveyController.java
@@ -4,7 +4,6 @@ import fastcampus.inguk_onboarding.common.response.ApiResponse;
 import fastcampus.inguk_onboarding.form.post.application.SurveyService;
 import fastcampus.inguk_onboarding.form.post.application.dto.CreateSurveyRequestDto;
 import fastcampus.inguk_onboarding.form.post.application.dto.SurveyResponseDto;
-import fastcampus.inguk_onboarding.form.post.domain.Survey;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;

--- a/project/inguk-onboarding/src/main/java/fastcampus/inguk_onboarding/form/ui/SurveyController.java
+++ b/project/inguk-onboarding/src/main/java/fastcampus/inguk_onboarding/form/ui/SurveyController.java
@@ -1,0 +1,29 @@
+package fastcampus.inguk_onboarding.form.ui;
+
+import fastcampus.inguk_onboarding.common.response.ApiResponse;
+import fastcampus.inguk_onboarding.form.post.application.SurveyService;
+import fastcampus.inguk_onboarding.form.post.application.dto.CreateSurveyRequestDto;
+import fastcampus.inguk_onboarding.form.post.application.dto.SurveyResponseDto;
+import fastcampus.inguk_onboarding.form.post.domain.Survey;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/survey")
+@RequiredArgsConstructor
+public class SurveyController {
+
+    private final SurveyService surveyService;
+
+    @PostMapping
+    public ResponseEntity<ApiResponse<SurveyResponseDto>> createSurvey(@Valid @RequestBody CreateSurveyRequestDto dto) {
+        SurveyResponseDto surveyResponse = surveyService.createSurvey(dto);
+        return ResponseEntity.ok(ApiResponse.success(surveyResponse));
+    }
+}

--- a/project/inguk-onboarding/src/main/resources/application-test.yml
+++ b/project/inguk-onboarding/src/main/resources/application-test.yml
@@ -1,0 +1,15 @@
+spring:
+  datasource:
+    url: jdbc:h2:mem:testdb;DB_CLOSE_DELAY=-1;MODE=MySQL
+    driver-class-name: org.h2.Driver
+    username: sa
+    password:
+  jpa:
+    hibernate:
+      ddl-auto: create-drop
+    properties:
+      hibernate:
+        dialect: org.hibernate.dialect.H2Dialect
+  h2:
+    console:
+      enabled: true

--- a/project/inguk-onboarding/src/main/resources/application.properties
+++ b/project/inguk-onboarding/src/main/resources/application.properties
@@ -1,1 +1,0 @@
-spring.application.name=inguk-onboarding

--- a/project/inguk-onboarding/src/main/resources/application.yml
+++ b/project/inguk-onboarding/src/main/resources/application.yml
@@ -1,0 +1,20 @@
+server:
+  port: 8080
+
+spring:
+  datasource:
+    url: jdbc:mysql://localhost:3037/fastcampusdb  # fastcampusdb 사용
+    username: root
+    password: root1234
+    driver-class-name: com.mysql.cj.jdbc.Driver
+
+  jpa:
+    hibernate:
+      ddl-auto: update  # 또는 create, validate
+    show-sql: true
+    properties:
+      hibernate:
+        format_sql: true
+        dialect: org.hibernate.dialect.MySQLDialect  # MySQL8Dialect 대신 MySQLDialect 사용
+    open-in-view: false
+

--- a/project/inguk-onboarding/src/test/java/fastcampus/inguk_onboarding/IngukOnboardingApplicationTests.java
+++ b/project/inguk-onboarding/src/test/java/fastcampus/inguk_onboarding/IngukOnboardingApplicationTests.java
@@ -2,8 +2,10 @@ package fastcampus.inguk_onboarding;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
 
 @SpringBootTest
+@ActiveProfiles("test")  // application-test.yml 사용
 class IngukOnboardingApplicationTests {
 
 	@Test


### PR DESCRIPTION
## Goal

설문조사 생성 API 

**### 주요 요구사항**

- 설문 생성API 지원
- 1~10개 질문, 4가지 입력 타입(단답/장문/단일선택/다중선택) 및 필수/선택 항목 지원

## Description
![아키텍처 패턴](https://github.com/user-attachments/assets/26419bb3-8868-4bbf-9ab7-3fe8322897a2)



## Additional Context (Optional)
개선 가능한 부분은 현재 도메인 계층이 상대적으로 약한것으로 파악, 강화가 필요함
인터페이스 정의에서는 application 과 Infrastructure 간의 인터페이스를 추가해야된다.
도메인 이벤츠 처리 메커니즘을 추가하면 더 좋을것으로 판단된다.

## Screenshots/Videos (Optional)


## References (Optional)



