### PR TITLE
feat/hyeongmin-onboarding-v0.0.4

### DIFF
--- a/project/hyeongmin-onboarding/NOTE.md
+++ b/project/hyeongmin-onboarding/NOTE.md
@@ -1,22 +1,25 @@
 # 2025-06-10 [v0.0.1]
+
 ## Changed or Added
+
 | ID 값 변경
-> Entity의 ID 값들이 @GeneratedValue(strategy = GenerationType.IDENTITY) 이어서 
+> Entity의 ID 값들이 @GeneratedValue(strategy = GenerationType.IDENTITY) 이어서
 > Transaction을 지원하는 쓰기 지연 방식이 동작하지 않으므로 변경이 필요하다고 인식
 > 다중환경(DB 분산 시) 일 경우에는 UUID 나 Snowflake 사용하는게 확장성 높으므로
 > Snowflake 모듈을 사용하여 AOP 작성, save* 로 캐치하여 id 값이 있을때 0 또는 null이면 값을 채우도록 함
 
-| Repository 추가 
+| Repository 추가
 > QueryDsl 사용으로 RepositoryCustomImpl 구현체 생성
 > 테스트 케이스 작성하면서 채울 예정
 
 ## fixed
 
-
 ## etc
 
 # 2025-06-11 [v0.0.1]
+
 ## Changed or Added
+
 | Exception Handler 추가
 > Exception 발생 시, 응답 구조를 컨트롤 하기 위해 추가
 > 사용자에게 보여 줄 메시지는 ErrorCode에 작성한 message를 보여주도록 하고
@@ -26,39 +29,42 @@
 
 | Survey Create API 추가
 > 설문조사 생성 API 추가 완료
-> 단순 Save 이므로 JPA Repository으로 처리 
+> 단순 Save 이므로 JPA Repository으로 처리
 
 ## fixed
-| Snowflake AOP 이슈 
+
+| Snowflake AOP 이슈
 > Snowflake가 오직 Spring Data 리포지토리(save(...)) 호출만 가로채기 때문에
 > surveyRepository.save(survey) 할 때 전달된 Survey 엔티티에만 ID를 채워주는 현상을 테스트케이스에서 발견
-> questions와 그 안의 QuestionOption들은 모두 JPA의 cascade persist 로 
+> questions와 그 안의 QuestionOption들은 모두 JPA의 cascade persist 로
 > EntityManager.persist()를 통해 직접 저장되기 때문에, 리포지토리의 save(...) 메서드를 거치지 않는 사실을 알게됨
 > 때문에 @onPrePersist (JPA 라이프사이클 콜백)을 사용하여 JPA 가 persist 하기 직전에 ID를 Snowflake 로 채우는 로직으로 변경
 > SnowflakeIdAspect 삭제 후 SnowflakeIdListener 생성
 
-
 # 2025-06-11 [v0.0.2]
+
 ## refactor
+
 - JPA 의 연관관게 (OneToMany) 사용하지 않도록 다시 모델링 작업함
 - 만든 모델링으로 전체적인 데이터 테이스 케이스 작성함
 - Snapshot 기반 데이터 체계 구현
-  - 설문조사 업데이트 시, Survey Version UP
-  - 모든 설문조사 응답 제출시, 질문과 응답은 각각 스냅샷으로 변경되어 디비에 저장
-  - 설문조사 응답을 조회하면 각각의 응답은 기존 질문과 응답을 스냅샷으로 가지고있음
+    - 설문조사 업데이트 시, Survey Version UP
+    - 모든 설문조사 응답 제출시, 질문과 응답은 각각 스냅샷으로 변경되어 디비에 저장
+    - 설문조사 응답을 조회하면 각각의 응답은 기존 질문과 응답을 스냅샷으로 가지고있음
 - DTO 기반 데이터 조립 Assembler 생성
-  - 모든 Entity의 조립은 Assembler 에서 담당하도록 함
+    - 모든 Entity의 조립은 Assembler 에서 담당하도록 함
 - 설문조사 제출시, 각각의 응답에는 질문타입이 있으므로 타입별 validation 체크와 Entity 조립을 위해 AnswerHandler 인터페이스 추가
-  - 추후 설문조사 응답에 타입이 추가되더라도 구현체를 하나 추가하면 되도록 함
-
+    - 추후 설문조사 응답에 타입이 추가되더라도 구현체를 하나 추가하면 되도록 함
 
 # 2025-06-15 [v0.0.3]
+
 ## refactor
+
 - Assembler 를 범용적으로, Context 추가시 소스 변경 없이 사용 할 수 있도록 변경
-  - AssemblyContext :  DTO를 만들기 위해 필요한 모든 데이터(Entity, 값 객체 등)를 담는 컨테이너
-  - AssemblerFactory : 어떤 DTO를 조립할지 결정하고, 알맞은 Assembler를 찾아 실행
-  - ContextKey<T> : AssemblyContext 내부에서 값을 식별하고, 꺼낼 때 타입 캐스팅을 보장하기 위한 Key 클래스
-  - Assembler<D> : DTO 한 종류를 조립하는 책임을 가지는 전략 객체
+    - AssemblyContext :  DTO를 만들기 위해 필요한 모든 데이터(Entity, 값 객체 등)를 담는 컨테이너
+    - AssemblerFactory : 어떤 DTO를 조립할지 결정하고, 알맞은 Assembler를 찾아 실행
+    - ContextKey<T> : AssemblyContext 내부에서 값을 식별하고, 꺼낼 때 타입 캐스팅을 보장하기 위한 Key 클래스
+    - Assembler<D> : DTO 한 종류를 조립하는 책임을 가지는 전략 객체
   ```
      Survey survey = Survey.builder()
                 .title(req.getTitle())
@@ -70,8 +76,22 @@
             assemblyContext.put(SURVEY_CONTEXT_KEY, survey);
         });
   ```
+
 # 2025-06-16 [v0.0.3]
+
 ## refactor
+
 - Assembler 추가
-  - 설문조사 응답 조회를 위한 Assembler 추가
+    - 설문조사 응답 조회를 위한 Assembler 추가
 - Assembler 를 활용한 시나리오 테스트
+
+# 2025-06-16 [v0.0.4]
+## feat
+- API 개발
+  - @PostMapping("/createSurvey")
+  - @PostMapping("/{surveyId}/submit")
+  - @GetMapping("/{surveyId}/responses")
+- JPAConfig 생성
+  - createAt, updateAt 자동 삽입
+- QuestionSnapshotDto, QuestionOptionSnapshotDto 로 Assemble 하도록 수정
+  - JPA 관계 쿼리때문에 스냅샷으로 저장되는 데이터의 양이 커지므로 DTO를 사용하여 데이터를 만들도록 

--- a/project/hyeongmin-onboarding/src/main/java/kr/co/fastcampus/onboarding/hyeongminonboarding/domain/api/survey/assembler/SurveyResponseDtoAssembler.java
+++ b/project/hyeongmin-onboarding/src/main/java/kr/co/fastcampus/onboarding/hyeongminonboarding/domain/api/survey/assembler/SurveyResponseDtoAssembler.java
@@ -22,7 +22,7 @@ public class SurveyResponseDtoAssembler implements Assembler<SurveyResponseDto> 
     public SurveyResponseDto assemble(AssemblyContext context) {
         Survey survey = context.get(SURVEY_CONTEXT_KEY);
         List<Question> questions = context.get(QUESTION_LIST_CONTEXT_KEY);
-        List<QuestionOption> questionOptions = context.get(QUESTION_OPTION_CONTEXT_KEY); // TODO : questionOptions 는 리스트가 아니라 Map 형태로 넣어야 할듯
+        List<QuestionOption> questionOptions = context.get(QUESTION_OPTION_LIST_CONTEXT_KEY); // TODO : questionOptions 는 리스트가 아니라 Map 형태로 넣어야 할듯
         List<SurveyResponseDto.QuestionResponseDto> questionResponseDtos =
                 questions.stream().map(question -> {
 

--- a/project/hyeongmin-onboarding/src/main/java/kr/co/fastcampus/onboarding/hyeongminonboarding/domain/api/survey/assembler/SurveyWithAnswersResponseDtoAssembler.java
+++ b/project/hyeongmin-onboarding/src/main/java/kr/co/fastcampus/onboarding/hyeongminonboarding/domain/api/survey/assembler/SurveyWithAnswersResponseDtoAssembler.java
@@ -2,7 +2,9 @@ package kr.co.fastcampus.onboarding.hyeongminonboarding.domain.api.survey.assemb
 
 import kr.co.fastcampus.onboarding.hyeongminonboarding.domain.api.survey.dto.response.SurveyWithAnswersResponseDto;
 import kr.co.fastcampus.onboarding.hyeongminonboarding.domain.api.survey.util.AnswerSnapshotSerializer;
-import kr.co.fastcampus.onboarding.hyeongminonboarding.domain.entity.*;
+import kr.co.fastcampus.onboarding.hyeongminonboarding.domain.entity.Answer;
+import kr.co.fastcampus.onboarding.hyeongminonboarding.domain.entity.Survey;
+import kr.co.fastcampus.onboarding.hyeongminonboarding.domain.entity.SurveyResponse;
 import kr.co.fastcampus.onboarding.hyeongminonboarding.global.dto.accembler.Assembler;
 import kr.co.fastcampus.onboarding.hyeongminonboarding.global.dto.accembler.impl.AssemblyContext;
 import lombok.RequiredArgsConstructor;
@@ -34,29 +36,18 @@ public class SurveyWithAnswersResponseDtoAssembler implements Assembler<SurveyWi
                             .answers(answers.stream().filter(
                                     f-> Objects.equals(f.getResponse().getId(), surveyResponse.getId()))
                                     .map(answer -> {
-                                        Question question = serializer.deserializeQuestion(answer.getQuestionSnapshotJson());
-                                        List<QuestionOption> options = serializer.deserializeOptions(answer.getOptionSnapshotJson());
+                                        SurveyWithAnswersResponseDto.QuestionSnapshotDto question = serializer.deserializeQuestion(answer.getQuestionSnapshotJson());
+                                        List<SurveyWithAnswersResponseDto.QuestionOptionSnapshotDto> options = serializer.deserializeOptions(answer.getOptionSnapshotJson());
                                         return SurveyWithAnswersResponseDto.AnswerDetailDto.builder()
                                                 .answerText(answer.getAnswerText())
                                                 .selectedOptionIds(answer.getSelectedOptionIds())
                                                 .questionId(answer.getQuestion().getId())
-                                                .required(question.isRequired())
+                                                .required(question.getRequired())
                                                 .questionType(question.getType())
                                                 .questionTitle(question.getTitle())
                                                 .questionDetail(question.getDetail())
-                                                .questionSnapshot(SurveyWithAnswersResponseDto.QuestionSnapshotDto.builder()
-                                                        .type(question.getType())
-                                                        .detail(question.getDetail())
-                                                        .title(question.getTitle())
-                                                        .required(question.isRequired())
-                                                        .build())
-                                                .optionSnapshot(options.stream().map(optionSnaps->{
-                                                    return SurveyWithAnswersResponseDto.QuestionOptionSnapshotDto.builder()
-                                                            .id(optionSnaps.getId())
-                                                            .optionValue(optionSnaps.getOptionValue())
-                                                            .build();
-                                                }).collect(Collectors.toList()))
-
+                                                .questionSnapshot(question)
+                                                .optionSnapshot(options)
                                                 .build();
 
                             }).collect(Collectors.toList()))

--- a/project/hyeongmin-onboarding/src/main/java/kr/co/fastcampus/onboarding/hyeongminonboarding/domain/api/survey/assembler/keys/SurveyContextKey.java
+++ b/project/hyeongmin-onboarding/src/main/java/kr/co/fastcampus/onboarding/hyeongminonboarding/domain/api/survey/assembler/keys/SurveyContextKey.java
@@ -15,6 +15,6 @@ public class SurveyContextKey {
     public static final ContextKey<List<Question>> QUESTION_LIST_CONTEXT_KEY =
             new ContextKey<>("questionList", List.class); // List<Question>는 선언 쪽에서만 유지됨
 
-    public static final ContextKey<List<QuestionOption>> QUESTION_OPTION_CONTEXT_KEY =
+    public static final ContextKey<List<QuestionOption>> QUESTION_OPTION_LIST_CONTEXT_KEY =
             new ContextKey<>("questionOptionList", List.class);
 }

--- a/project/hyeongmin-onboarding/src/main/java/kr/co/fastcampus/onboarding/hyeongminonboarding/domain/api/survey/controller/SurveyController.java
+++ b/project/hyeongmin-onboarding/src/main/java/kr/co/fastcampus/onboarding/hyeongminonboarding/domain/api/survey/controller/SurveyController.java
@@ -2,10 +2,10 @@ package kr.co.fastcampus.onboarding.hyeongminonboarding.domain.api.survey.contro
 
 
 import jakarta.validation.Valid;
-import kr.co.fastcampus.onboarding.hyeongminonboarding.domain.api.survey.dto.response.SurveyResponseDto;
-import kr.co.fastcampus.onboarding.hyeongminonboarding.domain.api.survey.dto.request.SubmitAnswerRequest;
+import kr.co.fastcampus.onboarding.hyeongminonboarding.domain.api.survey.dto.request.SubmitSurveyAnswersRequest;
 import kr.co.fastcampus.onboarding.hyeongminonboarding.domain.api.survey.dto.request.SurveyCreateRequest;
 import kr.co.fastcampus.onboarding.hyeongminonboarding.domain.api.survey.dto.request.SurveyUpdateRequest;
+import kr.co.fastcampus.onboarding.hyeongminonboarding.domain.api.survey.dto.response.SurveyResponseDto;
 import kr.co.fastcampus.onboarding.hyeongminonboarding.domain.api.survey.dto.response.SurveyWithAnswersResponseDto;
 import kr.co.fastcampus.onboarding.hyeongminonboarding.domain.api.survey.service.ISurveyService;
 import kr.co.fastcampus.onboarding.hyeongminonboarding.global.dto.request.BaseRequest;
@@ -42,14 +42,14 @@ public class SurveyController {
     @PostMapping("/{surveyId}/submit")
     public BaseResponse<Void> submitSurveyAnswers(
             @PathVariable Long surveyId,
-            @Valid @RequestBody BaseRequest<SubmitAnswerRequest> request
+            @Valid @RequestBody BaseRequest<SubmitSurveyAnswersRequest> request
     ) {
         this.surveyService.submitSurveyAnswer(surveyId, request);
         return BaseResponse.OK();
     }
 
     // 4. 설문조사 응답 조회
-    @GetMapping("/{surveyId}/response")
+    @GetMapping("/{surveyId}/responses")
     public BaseResponse<SurveyWithAnswersResponseDto> getSurveyResponses(
             @PathVariable Long surveyId
     ) {

--- a/project/hyeongmin-onboarding/src/main/java/kr/co/fastcampus/onboarding/hyeongminonboarding/domain/api/survey/dto/request/SubmitAnswerRequest.java
+++ b/project/hyeongmin-onboarding/src/main/java/kr/co/fastcampus/onboarding/hyeongminonboarding/domain/api/survey/dto/request/SubmitAnswerRequest.java
@@ -17,7 +17,6 @@ import java.util.List;
 public class SubmitAnswerRequest {
     @NotNull
     private Long questionId;
-    private QuestionType questionType;
 
     private String answerText; // 단답/장문형일 경우 (ValidCheck 안됨 서비스단에서 함)
     private List<Long> selectedOptionIds; // 선택형일 경우 (ValidCheck 암됨 서비스단에서 함)

--- a/project/hyeongmin-onboarding/src/main/java/kr/co/fastcampus/onboarding/hyeongminonboarding/domain/api/survey/dto/request/SubmitSurveyAnswersRequest.java
+++ b/project/hyeongmin-onboarding/src/main/java/kr/co/fastcampus/onboarding/hyeongminonboarding/domain/api/survey/dto/request/SubmitSurveyAnswersRequest.java
@@ -1,0 +1,21 @@
+package kr.co.fastcampus.onboarding.hyeongminonboarding.domain.api.survey.dto.request;
+
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotEmpty;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class SubmitSurveyAnswersRequest {
+    @NotEmpty
+    @Valid
+    private List<SubmitAnswerRequest> answers;
+}

--- a/project/hyeongmin-onboarding/src/main/java/kr/co/fastcampus/onboarding/hyeongminonboarding/domain/api/survey/dto/response/SurveyWithAnswersResponseDto.java
+++ b/project/hyeongmin-onboarding/src/main/java/kr/co/fastcampus/onboarding/hyeongminonboarding/domain/api/survey/dto/response/SurveyWithAnswersResponseDto.java
@@ -1,8 +1,10 @@
 package kr.co.fastcampus.onboarding.hyeongminonboarding.domain.api.survey.dto.response;
 
 import kr.co.fastcampus.onboarding.hyeongminonboarding.domain.entity.enums.QuestionType;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -47,15 +49,21 @@ public class SurveyWithAnswersResponseDto {
 
     @Data
     @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
     public static class QuestionSnapshotDto {
         private String title;
         private QuestionType type;
         private Boolean required;
         private String detail;
+
+
     }
 
     @Data
     @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
     public static class QuestionOptionSnapshotDto {
         private Long id;
         private String optionValue;

--- a/project/hyeongmin-onboarding/src/main/java/kr/co/fastcampus/onboarding/hyeongminonboarding/domain/api/survey/service/ISurveyService.java
+++ b/project/hyeongmin-onboarding/src/main/java/kr/co/fastcampus/onboarding/hyeongminonboarding/domain/api/survey/service/ISurveyService.java
@@ -1,5 +1,6 @@
 package kr.co.fastcampus.onboarding.hyeongminonboarding.domain.api.survey.service;
 
+import kr.co.fastcampus.onboarding.hyeongminonboarding.domain.api.survey.dto.request.SubmitSurveyAnswersRequest;
 import kr.co.fastcampus.onboarding.hyeongminonboarding.domain.api.survey.dto.response.SurveyResponseDto;
 import kr.co.fastcampus.onboarding.hyeongminonboarding.domain.api.survey.dto.request.SubmitAnswerRequest;
 import kr.co.fastcampus.onboarding.hyeongminonboarding.domain.api.survey.dto.request.SurveyCreateRequest;
@@ -36,7 +37,7 @@ public interface ISurveyService {
      * @param surveyId 응답할 설문조사 ID
      * @param request 응답 제출 요청 정보
      */
-    void submitSurveyAnswer(Long surveyId, BaseRequest<SubmitAnswerRequest> request);
+    void submitSurveyAnswer(Long surveyId, BaseRequest<SubmitSurveyAnswersRequest> request);
 
     /**
      * 설문조사에 제출된 전체 응답을 조회합니다.

--- a/project/hyeongmin-onboarding/src/main/java/kr/co/fastcampus/onboarding/hyeongminonboarding/domain/api/survey/service/impl/SurveyService.java
+++ b/project/hyeongmin-onboarding/src/main/java/kr/co/fastcampus/onboarding/hyeongminonboarding/domain/api/survey/service/impl/SurveyService.java
@@ -1,24 +1,32 @@
 package kr.co.fastcampus.onboarding.hyeongminonboarding.domain.api.survey.service.impl;
 
+import jakarta.persistence.EntityNotFoundException;
 import kr.co.fastcampus.onboarding.hyeongminonboarding.domain.api.survey.assembler.SurveyResponseDtoAssembler;
+import kr.co.fastcampus.onboarding.hyeongminonboarding.domain.api.survey.assembler.keys.SurveyContextKey;
 import kr.co.fastcampus.onboarding.hyeongminonboarding.domain.api.survey.dto.request.SubmitAnswerRequest;
+import kr.co.fastcampus.onboarding.hyeongminonboarding.domain.api.survey.dto.request.SubmitSurveyAnswersRequest;
 import kr.co.fastcampus.onboarding.hyeongminonboarding.domain.api.survey.dto.request.SurveyCreateRequest;
 import kr.co.fastcampus.onboarding.hyeongminonboarding.domain.api.survey.dto.request.SurveyUpdateRequest;
 import kr.co.fastcampus.onboarding.hyeongminonboarding.domain.api.survey.dto.response.SurveyResponseDto;
 import kr.co.fastcampus.onboarding.hyeongminonboarding.domain.api.survey.dto.response.SurveyWithAnswersResponseDto;
 import kr.co.fastcampus.onboarding.hyeongminonboarding.domain.api.survey.service.ISurveyService;
-import kr.co.fastcampus.onboarding.hyeongminonboarding.domain.entity.Survey;
-import kr.co.fastcampus.onboarding.hyeongminonboarding.domain.repository.AnswerRepository;
-import kr.co.fastcampus.onboarding.hyeongminonboarding.domain.repository.QuestionOptionRepository;
-import kr.co.fastcampus.onboarding.hyeongminonboarding.domain.repository.QuestionRepository;
-import kr.co.fastcampus.onboarding.hyeongminonboarding.domain.repository.SurveyRepository;
+import kr.co.fastcampus.onboarding.hyeongminonboarding.domain.api.survey.util.AnswerSnapshotSerializer;
+import kr.co.fastcampus.onboarding.hyeongminonboarding.domain.entity.*;
+import kr.co.fastcampus.onboarding.hyeongminonboarding.domain.entity.enums.QuestionType;
+import kr.co.fastcampus.onboarding.hyeongminonboarding.domain.exception.SurveyException;
+import kr.co.fastcampus.onboarding.hyeongminonboarding.domain.repository.*;
 import kr.co.fastcampus.onboarding.hyeongminonboarding.global.dto.accembler.impl.AssemblerFactory;
 import kr.co.fastcampus.onboarding.hyeongminonboarding.global.dto.request.BaseRequest;
+import kr.co.fastcampus.onboarding.hyeongminonboarding.global.exception.enums.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.CollectionUtils;
 
-import static kr.co.fastcampus.onboarding.hyeongminonboarding.domain.api.survey.assembler.keys.SurveyContextKey.SURVEY_CONTEXT_KEY;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
 
 
 @Service
@@ -29,24 +37,67 @@ public class SurveyService implements ISurveyService {
     private final QuestionOptionRepository questionOptionRepository;
     private final QuestionRepository questionRepository;
     private final SurveyRepository surveyRepository;
+    private final SurveyResponseRepository surveyResponseRepository;
     private final SurveyResponseDtoAssembler surveyAssembler;
     private final AssemblerFactory assemblerFactory;
+    private final AnswerSnapshotSerializer serializer;
 
 
     @Transactional
     @Override
-    public SurveyResponseDto createSurvey(BaseRequest<SurveyCreateRequest> request) {
-        SurveyCreateRequest req = request.getBody();
+    public SurveyResponseDto createSurvey(BaseRequest<SurveyCreateRequest> req) {
+        SurveyCreateRequest request = req.getBody();
 
-        Survey survey = Survey.builder()
-                .title(req.getTitle())
-                .description(req.getDescription())
-                .version(1)
-                .build();
+        // Survey 저장
+        Survey survey = surveyRepository.save(
+                Survey.builder()
+                        .title(request.getTitle())
+                        .description(request.getDescription())
+                        .version(1)
+                        .build()
+        );
 
-        return assemblerFactory.assemble(SurveyResponseDto.class, assemblyContext -> {
-            assemblyContext.put(SURVEY_CONTEXT_KEY, survey);
-        });
+        // Question 엔티티 일괄 생성
+        List<Question> questions = request.getQuestions().stream()
+                .map(qr -> Question.builder()
+                        .survey(survey)
+                        .title(qr.getTitle())
+                        .detail(qr.getDetail())
+                        .type(qr.getType())
+                        .required(qr.isRequired())
+                        .build()
+                ).toList();
+
+        questions = questionRepository.saveAll(questions);
+
+        // QuestionOption 엔티티 일괄 생성
+        List<QuestionOption> allOptions = new ArrayList<>();
+        for (int i = 0; i < request.getQuestions().size(); i++) {
+            var qr = request.getQuestions().get(i);
+            if (qr.getType().isChoiceType() && qr.getOptions() != null) {
+                Question parent = questions.get(i);
+                qr.getOptions().stream()
+                        .map(val -> QuestionOption.builder()
+                                .question(parent)
+                                .optionValue(val)
+                                .build()
+                        )
+                        .forEach(allOptions::add);
+            }
+        }
+
+        List<QuestionOption> options = questionOptionRepository.saveAll(allOptions);
+
+        // DTO 조립해서 반환
+        List<Question> finalQuestions = questions;
+        return assemblerFactory.assemble(
+                SurveyResponseDto.class,
+                ctx -> {
+                    ctx.put(SurveyContextKey.SURVEY_CONTEXT_KEY, survey);
+                    ctx.put(SurveyContextKey.QUESTION_LIST_CONTEXT_KEY, finalQuestions);
+                    ctx.put(SurveyContextKey.QUESTION_OPTION_LIST_CONTEXT_KEY, options);
+                }
+        );
     }
 
     @Override
@@ -57,12 +108,78 @@ public class SurveyService implements ISurveyService {
 
     @Override
     @Transactional
-    public void submitSurveyAnswer(Long surveyId, BaseRequest<SubmitAnswerRequest> request) {
+    public void submitSurveyAnswer(Long surveyId, BaseRequest<SubmitSurveyAnswersRequest> request) {
+        SubmitSurveyAnswersRequest req = request.getBody();
 
+        // 설문 조사 존재 확인
+        Survey survey = surveyRepository.findById(surveyId)
+                .orElseThrow(() -> new EntityNotFoundException("Survey not found: " + surveyId));
+
+        // SurveyResponse 생성
+        SurveyResponse resp = surveyResponseRepository.save(
+                SurveyResponse.builder()
+                        .survey(survey)
+                        .surveyVersion(survey.getVersion())
+                        .submittedAt(LocalDateTime.now())
+                        .build()
+        );
+
+        // 요청으로 넘어온 모든 답변 처리
+        for (SubmitAnswerRequest ansReq : req.getAnswers()) {
+            // 질문 조회
+            Question question = questionRepository.findById(ansReq.getQuestionId())
+                    .orElseThrow(() -> new EntityNotFoundException("Question not found: " + ansReq.getQuestionId()));
+
+
+            if(
+                    (question.getType() == QuestionType.SINGLE_CHOICE ||
+                            question.getType() == QuestionType.MULTIPLE_CHOICE ) &&
+                            CollectionUtils.isEmpty(ansReq.getSelectedOptionIds())
+            ){
+                throw new SurveyException(ErrorCode.SURVEY_QUESTION_OPTION_EMPTY);
+            }
+            // 스냅샷 JSON
+            String qSnap = serializer.serializeQuestion(question);
+            String optsSnap = serializer.serializeOptions(
+                    questionOptionRepository.findByQuestionId(question.getId())
+            );
+
+            // Answer 엔티티 빌드
+            Answer.AnswerBuilder ab = Answer.builder()
+                    .response(resp)
+                    .question(question)
+                    .questionSnapshotJson(qSnap)
+                    .optionSnapshotJson(optsSnap);
+
+            if (ansReq.getAnswerText() != null) {
+                ab.answerText(ansReq.getAnswerText());
+            }
+            if (ansReq.getSelectedOptionIds() != null) {
+                ab.selectedOptionIds(ansReq.getSelectedOptionIds());
+            }
+
+            answerRepository.save(ab.build());
+        }
     }
 
     @Override
+    @Transactional(readOnly = true)
     public SurveyWithAnswersResponseDto getSurveyResponses(Long surveyId) {
-        return null;
+        Survey survey = surveyRepository.findById(surveyId)
+                .orElseThrow(() -> new EntityNotFoundException("Survey not found: " + surveyId));
+
+        List<SurveyResponse> responses =
+                surveyResponseRepository.findAllBySurveyIdOrderBySubmittedAtAsc(surveyId);
+
+        List<Answer> answers = answerRepository.findAllByResponseIn(responses);
+
+        return assemblerFactory.assemble(
+                SurveyWithAnswersResponseDto.class,
+                ctx -> {
+                    ctx.put(SurveyContextKey.SURVEY_CONTEXT_KEY, survey);
+                    ctx.put(SurveyContextKey.SURVEY_RESPONSE_LIST_CONTEXT_KEY, responses);
+                    ctx.put(SurveyContextKey.ANSWER_LIST_CONTEXT_KEY, answers);
+                }
+        );
     }
 }

--- a/project/hyeongmin-onboarding/src/main/java/kr/co/fastcampus/onboarding/hyeongminonboarding/domain/api/survey/util/AnswerSnapshotSerializer.java
+++ b/project/hyeongmin-onboarding/src/main/java/kr/co/fastcampus/onboarding/hyeongminonboarding/domain/api/survey/util/AnswerSnapshotSerializer.java
@@ -3,9 +3,9 @@ package kr.co.fastcampus.onboarding.hyeongminonboarding.domain.api.survey.util;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import kr.co.fastcampus.onboarding.hyeongminonboarding.domain.api.survey.dto.response.SurveyWithAnswersResponseDto;
 import kr.co.fastcampus.onboarding.hyeongminonboarding.domain.entity.Question;
 import kr.co.fastcampus.onboarding.hyeongminonboarding.domain.entity.QuestionOption;
-import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
 import java.util.Arrays;
@@ -21,32 +21,44 @@ public class AnswerSnapshotSerializer {
     }
 
     public String serializeQuestion(Question question) {
+        SurveyWithAnswersResponseDto.QuestionSnapshotDto snap = SurveyWithAnswersResponseDto.QuestionSnapshotDto.builder()
+                .title(question.getTitle())
+                .detail(question.getDetail())
+                .type(question.getType())
+                .required(question.isRequired())
+                .build();
         try {
-            return objectMapper.writeValueAsString(question);
+            return objectMapper.writeValueAsString(snap);
         } catch (JsonProcessingException e) {
             throw new RuntimeException("질문 스냅샷 직렬화 실패", e);
         }
     }
 
     public String serializeOptions(List<QuestionOption> options) {
+        List<SurveyWithAnswersResponseDto.QuestionOptionSnapshotDto> snaps = options.stream()
+                .map(opt -> SurveyWithAnswersResponseDto.QuestionOptionSnapshotDto.builder()
+                        .id(opt.getId())
+                        .optionValue(opt.getOptionValue())
+                        .build())
+                .toList();
         try {
-            return objectMapper.writeValueAsString(options);
+            return objectMapper.writeValueAsString(snaps);
         } catch (JsonProcessingException e) {
             throw new RuntimeException("선택지 스냅샷 직렬화 실패", e);
         }
     }
 
-    public Question deserializeQuestion(String json) {
+    public SurveyWithAnswersResponseDto.QuestionSnapshotDto deserializeQuestion(String json) {
         try {
-            return objectMapper.readValue(json, Question.class);
+            return objectMapper.readValue(json, SurveyWithAnswersResponseDto.QuestionSnapshotDto.class);
         } catch (JsonProcessingException e) {
             throw new RuntimeException("질문 스냅샷 역직렬화 실패", e);
         }
     }
 
-    public List<QuestionOption> deserializeOptions(String json) {
+    public List<SurveyWithAnswersResponseDto.QuestionOptionSnapshotDto> deserializeOptions(String json) {
         try {
-            return Arrays.asList(objectMapper.readValue(json, QuestionOption[].class));
+            return Arrays.asList(objectMapper.readValue(json, SurveyWithAnswersResponseDto.QuestionOptionSnapshotDto[].class));
         } catch (JsonProcessingException e) {
             throw new RuntimeException("옵션 스냅샷 역직렬화 실패", e);
         }

--- a/project/hyeongmin-onboarding/src/main/java/kr/co/fastcampus/onboarding/hyeongminonboarding/domain/repository/AnswerRepository.java
+++ b/project/hyeongmin-onboarding/src/main/java/kr/co/fastcampus/onboarding/hyeongminonboarding/domain/repository/AnswerRepository.java
@@ -1,7 +1,11 @@
 package kr.co.fastcampus.onboarding.hyeongminonboarding.domain.repository;
 
 import kr.co.fastcampus.onboarding.hyeongminonboarding.domain.entity.Answer;
+import kr.co.fastcampus.onboarding.hyeongminonboarding.domain.entity.SurveyResponse;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface AnswerRepository extends JpaRepository<Answer, Long> ,AnswerRepositoryCustom {
+    List<Answer> findAllByResponseIn(List<SurveyResponse> responses);
 }

--- a/project/hyeongmin-onboarding/src/main/java/kr/co/fastcampus/onboarding/hyeongminonboarding/domain/repository/QuestionOptionRepository.java
+++ b/project/hyeongmin-onboarding/src/main/java/kr/co/fastcampus/onboarding/hyeongminonboarding/domain/repository/QuestionOptionRepository.java
@@ -3,5 +3,8 @@ package kr.co.fastcampus.onboarding.hyeongminonboarding.domain.repository;
 import kr.co.fastcampus.onboarding.hyeongminonboarding.domain.entity.QuestionOption;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface QuestionOptionRepository extends JpaRepository<QuestionOption, Long>, QuestionRepositoryCustom {
+    List<QuestionOption> findByQuestionId(Long id);
 }

--- a/project/hyeongmin-onboarding/src/main/java/kr/co/fastcampus/onboarding/hyeongminonboarding/domain/repository/SurveyResponseRepository.java
+++ b/project/hyeongmin-onboarding/src/main/java/kr/co/fastcampus/onboarding/hyeongminonboarding/domain/repository/SurveyResponseRepository.java
@@ -3,5 +3,8 @@ package kr.co.fastcampus.onboarding.hyeongminonboarding.domain.repository;
 import kr.co.fastcampus.onboarding.hyeongminonboarding.domain.entity.SurveyResponse;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface SurveyResponseRepository extends JpaRepository<SurveyResponse, Long>,SurveyResponseRepositoryCustom {
+    List<SurveyResponse> findAllBySurveyIdOrderBySubmittedAtAsc(Long surveyId);
 }

--- a/project/hyeongmin-onboarding/src/main/java/kr/co/fastcampus/onboarding/hyeongminonboarding/global/config/JpaConfig.java
+++ b/project/hyeongmin-onboarding/src/main/java/kr/co/fastcampus/onboarding/hyeongminonboarding/global/config/JpaConfig.java
@@ -1,0 +1,9 @@
+package kr.co.fastcampus.onboarding.hyeongminonboarding.global.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@Configuration
+@EnableJpaAuditing
+public class JpaConfig {
+}

--- a/project/hyeongmin-onboarding/src/main/resources/application.properties
+++ b/project/hyeongmin-onboarding/src/main/resources/application.properties
@@ -1,16 +1,16 @@
 spring.application.name=hyeongmin-onboarding
 
 ## In Memory
-#spring.datasource.url=jdbc:h2:mem:testdb;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
+#spring.datasource.url=jdbc:h2:mem:survey_db;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
 ## In Disk
 spring.datasource.url=jdbc:h2:file:./data/survey_db;DB_CLOSE_ON_EXIT=FALSE
 spring.datasource.driver-class-name=org.h2.Driver
 spring.datasource.username=sa
 spring.datasource.password=
-
 spring.jpa.database-platform=org.hibernate.dialect.H2Dialect
 spring.jpa.hibernate.ddl-auto=update
 spring.jpa.show-sql=true
+spring.jpa.properties.hibernate.jdbc.batch_size=50
 
 spring.h2.console.enabled=true
 spring.h2.console.path=/h2-console

--- a/project/hyeongmin-onboarding/src/test/java/https/crud.http
+++ b/project/hyeongmin-onboarding/src/test/java/https/crud.http
@@ -1,0 +1,89 @@
+### Create Survey
+POST http://localhost:8080/api/survey/createSurvey
+Content-Type: application/json
+
+{
+  "body": {
+    "title": "서비스 만족도 조사",
+    "description": "우리 서비스에 대한 전반적인 만족도를 조사합니다.",
+    "questions": [
+      {
+        "title": "서비스를 어떻게 알게 되었나요?",
+        "detail": "예: 친구 추천, 검색 등",
+        "type": "SHORT_TEXT",
+        "required": true
+      },
+      {
+        "title": "가장 만족한 기능은 무엇인가요?",
+        "detail": null,
+        "type": "LONG_TEXT",
+        "required": false
+      },
+      {
+        "title": "향후 개선되었으면 하는 부분을 선택해주세요.",
+        "detail": null,
+        "type": "MULTIPLE_CHOICE",
+        "required": true,
+        "options": [
+          "UI/UX",
+          "성능",
+          "고객지원",
+          "기능 추가"
+        ]
+      },
+      {
+        "title": "당신의 성별을 선택해 주세요.",
+        "detail": null,
+        "type": "SINGLE_CHOICE",
+        "required": true,
+        "options": [
+          "남자",
+          "여자"
+        ]
+      }
+    ]
+  }
+}
+
+
+
+### Submit Survey Answers
+POST http://localhost:8080/api/survey/1934603757543362560/submit
+Content-Type: application/json
+
+{
+  "body": {
+    "answers": [
+      {
+        "questionId": 1934603757585305600,
+        "answerText": "친구 추천",
+        "selectedOptionIds": null
+      },
+      {
+        "questionId": 1934603757585305600,
+        "answerText": "검색엔진에서 발견했습니다.",
+        "selectedOptionIds": null
+      },
+      {
+        "questionId": 1934603757593694209,
+        "answerText": null,
+        "selectedOptionIds": [
+          1934603757597888512,
+          1934603757597888513
+        ]
+      },
+      {
+        "questionId": 1934603757593694210,
+        "answerText": null,
+        "selectedOptionIds": [
+          1934603757597888516
+        ]
+      }
+    ]
+  }
+}
+
+
+### Get Survey Responses
+GET http://localhost:8080/api/survey/1934603757543362560/responses
+Accept: application/json

--- a/project/hyeongmin-onboarding/src/test/java/kr/co/fastcampus/onboarding/hyeongminonboarding/functionTest/AnswerSnapshotSerializerTest.java
+++ b/project/hyeongmin-onboarding/src/test/java/kr/co/fastcampus/onboarding/hyeongminonboarding/functionTest/AnswerSnapshotSerializerTest.java
@@ -1,6 +1,7 @@
 package kr.co.fastcampus.onboarding.hyeongminonboarding.functionTest;
 
 
+import kr.co.fastcampus.onboarding.hyeongminonboarding.domain.api.survey.dto.response.SurveyWithAnswersResponseDto;
 import kr.co.fastcampus.onboarding.hyeongminonboarding.domain.api.survey.util.AnswerSnapshotSerializer;
 import kr.co.fastcampus.onboarding.hyeongminonboarding.domain.entity.Question;
 import kr.co.fastcampus.onboarding.hyeongminonboarding.domain.entity.QuestionOption;
@@ -41,8 +42,8 @@ public class AnswerSnapshotSerializerTest {
         String questionJson = serializer.serializeQuestion(question);
         String optionJson = serializer.serializeOptions(options);
 
-        Question restoredQuestion = serializer.deserializeQuestion(questionJson);
-        List<QuestionOption> restoredOptions = serializer.deserializeOptions(optionJson);
+        SurveyWithAnswersResponseDto.QuestionSnapshotDto restoredQuestion = serializer.deserializeQuestion(questionJson);
+        List<SurveyWithAnswersResponseDto.QuestionOptionSnapshotDto> restoredOptions = serializer.deserializeOptions(optionJson);
 
         // then
         assertEquals(question.getTitle(), restoredQuestion.getTitle());

--- a/project/hyeongmin-onboarding/src/test/java/kr/co/fastcampus/onboarding/hyeongminonboarding/functionTest/AssemblerTest.java
+++ b/project/hyeongmin-onboarding/src/test/java/kr/co/fastcampus/onboarding/hyeongminonboarding/functionTest/AssemblerTest.java
@@ -100,7 +100,7 @@ public class AssemblerTest {
                 ctx -> {
                     ctx.put(SurveyContextKey.SURVEY_CONTEXT_KEY, survey);
                     ctx.put(SurveyContextKey.QUESTION_LIST_CONTEXT_KEY, questions);
-                    ctx.put(SurveyContextKey.QUESTION_OPTION_CONTEXT_KEY, options);
+                    ctx.put(SurveyContextKey.QUESTION_OPTION_LIST_CONTEXT_KEY, options);
                 }
         );
 
@@ -162,7 +162,7 @@ public class AssemblerTest {
                 ctx -> {
                     ctx.put(SurveyContextKey.SURVEY_CONTEXT_KEY, survey);
                     ctx.put(SurveyContextKey.QUESTION_LIST_CONTEXT_KEY, questions);
-                    ctx.put(SurveyContextKey.QUESTION_OPTION_CONTEXT_KEY, options);
+                    ctx.put(SurveyContextKey.QUESTION_OPTION_LIST_CONTEXT_KEY, options);
                 }
         );
         assertEquals(1, dto.getQuestions().size());
@@ -261,7 +261,7 @@ public class AssemblerTest {
                 ctx -> {
                     ctx.put(SurveyContextKey.SURVEY_CONTEXT_KEY, survey);
                     ctx.put(SurveyContextKey.QUESTION_LIST_CONTEXT_KEY, questions);
-                    ctx.put(SurveyContextKey.QUESTION_OPTION_CONTEXT_KEY, options);
+                    ctx.put(SurveyContextKey.QUESTION_OPTION_LIST_CONTEXT_KEY, options);
                 }
         );
         long elapsed = System.currentTimeMillis() - start;
@@ -290,7 +290,7 @@ public class AssemblerTest {
                 ctx -> {
                     ctx.put(SurveyContextKey.SURVEY_CONTEXT_KEY, survey);
                     ctx.put(SurveyContextKey.QUESTION_LIST_CONTEXT_KEY, questions);
-                    ctx.put(SurveyContextKey.QUESTION_OPTION_CONTEXT_KEY, options);
+                    ctx.put(SurveyContextKey.QUESTION_OPTION_LIST_CONTEXT_KEY, options);
                 }
         );
 
@@ -372,7 +372,7 @@ public class AssemblerTest {
                 ctx -> {
                     ctx.put(SurveyContextKey.SURVEY_CONTEXT_KEY, survey);
                     ctx.put(SurveyContextKey.QUESTION_LIST_CONTEXT_KEY, qs);
-                    ctx.put(SurveyContextKey.QUESTION_OPTION_CONTEXT_KEY, opts);
+                    ctx.put(SurveyContextKey.QUESTION_OPTION_LIST_CONTEXT_KEY, opts);
                 }
         );
         long durationMs = (System.nanoTime() - t0) / 1_000_000;

--- a/project/hyeongmin-onboarding/src/test/java/kr/co/fastcampus/onboarding/hyeongminonboarding/modeling/ModelingTest.java
+++ b/project/hyeongmin-onboarding/src/test/java/kr/co/fastcampus/onboarding/hyeongminonboarding/modeling/ModelingTest.java
@@ -4,12 +4,13 @@ package kr.co.fastcampus.onboarding.hyeongminonboarding.modeling;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.transaction.NotSupportedException;
+import kr.co.fastcampus.onboarding.hyeongminonboarding.domain.api.survey.dto.request.SubmitAnswerRequest;
+import kr.co.fastcampus.onboarding.hyeongminonboarding.domain.api.survey.dto.response.SurveyWithAnswersResponseDto;
 import kr.co.fastcampus.onboarding.hyeongminonboarding.domain.api.survey.handler.AnswerHandler;
 import kr.co.fastcampus.onboarding.hyeongminonboarding.domain.api.survey.handler.AnswerHandlerFactory;
-import kr.co.fastcampus.onboarding.hyeongminonboarding.domain.api.survey.dto.request.SubmitAnswerRequest;
+import kr.co.fastcampus.onboarding.hyeongminonboarding.domain.api.survey.util.AnswerSnapshotSerializer;
 import kr.co.fastcampus.onboarding.hyeongminonboarding.domain.entity.*;
 import kr.co.fastcampus.onboarding.hyeongminonboarding.domain.entity.enums.QuestionType;
-import kr.co.fastcampus.onboarding.hyeongminonboarding.domain.api.survey.util.AnswerSnapshotSerializer;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -241,8 +242,8 @@ public class ModelingTest {
         );
 
         // 스냅샷 역직렬화
-        Question snapshotQuestion = snapshotSerializer.deserializeQuestion(answer.getQuestionSnapshotJson());
-        List<QuestionOption> snapshotOptions = snapshotSerializer.deserializeOptions(answer.getOptionSnapshotJson());
+        SurveyWithAnswersResponseDto.QuestionSnapshotDto snapshotQuestion = snapshotSerializer.deserializeQuestion(answer.getQuestionSnapshotJson());
+        List<SurveyWithAnswersResponseDto.QuestionOptionSnapshotDto> snapshotOptions = snapshotSerializer.deserializeOptions(answer.getOptionSnapshotJson());
 
         // 검증
         assertEquals("성별을 선택하세요", snapshotQuestion.getTitle());


### PR DESCRIPTION
# 2025-06-16 [v0.0.4]
## feat
- API 개발
  - @PostMapping("/createSurvey")
  - @PostMapping("/{surveyId}/submit")
  - @GetMapping("/{surveyId}/responses")
- JPAConfig 생성
  - createAt, updateAt 자동 삽입
- QuestionSnapshotDto, QuestionOptionSnapshotDto 로 Assemble 하도록 수정
  - JPA 관계 쿼리때문에 스냅샷으로 저장되는 데이터의 양이 커지므로 DTO를 사용하여 데이터를 만들도록