### PR TITLE
feat/hyeongmin-onboarding-v0.0.5

### DIFF
--- a/project/hyeongmin-onboarding/NOTE.md
+++ b/project/hyeongmin-onboarding/NOTE.md
@@ -94,4 +94,19 @@
 - JPAConfig 생성
   - createAt, updateAt 자동 삽입
 - QuestionSnapshotDto, QuestionOptionSnapshotDto 로 Assemble 하도록 수정
-  - JPA 관계 쿼리때문에 스냅샷으로 저장되는 데이터의 양이 커지므로 DTO를 사용하여 데이터를 만들도록 
+  - JPA 관계 쿼리때문에 스냅샷으로 저장되는 데이터의 양이 커지므로 DTO를 사용하여 데이터를 만들도록
+
+# 2025-06-17 [v0.0.5]
+## feat
+- API 개발
+  - @PutMapping("/{surveyId}")
+    - 설문조사 수정을 위해, Question 엔티티에 deleted 컬럼 추가
+    - 설문조사 수정 Request에서 각각의 Question ID를 있으면 받고 없으면 받지 않도록함
+    - Question ID 가 존재하면 soft-delete 로 deleted를 수정
+    - Question ID 가 존재하지 않으면 새로 생성
+    - Question Option은 Delete Insert 전략 사용
+  - @GetMapping("/{surveyId})
+    - 생성된 설문조사 1개의 양식을 최신상태로 조회하여 볼 수 있도록 새로 생성함
+## todo
+- Question 을 soft-delete 로 삭제하는 것으로 변경하니, QuestionSnapshot이 의미가 없어졌으므로 리팩토링에서 삭제해야 함
+- Assemble 에서 엔티티를 리스트형식으로만 받으니 순환조회하여 ID 값을 맵핑하므로 Map 형식으로 받도록 리팩토링해야 함

--- a/project/hyeongmin-onboarding/src/main/java/kr/co/fastcampus/onboarding/hyeongminonboarding/domain/api/survey/controller/SurveyController.java
+++ b/project/hyeongmin-onboarding/src/main/java/kr/co/fastcampus/onboarding/hyeongminonboarding/domain/api/survey/controller/SurveyController.java
@@ -50,10 +50,19 @@ public class SurveyController {
 
     // 4. 설문조사 응답 조회
     @GetMapping("/{surveyId}/responses")
-    public BaseResponse<SurveyWithAnswersResponseDto> getSurveyResponses(
+    public BaseResponse<SurveyWithAnswersResponseDto> getSurveyWithAnswerResponses(
             @PathVariable Long surveyId
     ) {
-        return BaseResponse.OK(this.surveyService.getSurveyResponses(surveyId));
+        return BaseResponse.OK(this.surveyService.getSurveyWithAnswerResponses(surveyId));
+    }
+
+
+    // 5. 설문조사 상세
+    @GetMapping("/{surveyId}")
+    public BaseResponse<SurveyResponseDto> getSurveyResponse(
+            @PathVariable Long surveyId
+    ) {
+        return BaseResponse.OK(this.surveyService.getSurveyResponse(surveyId));
     }
 
 

--- a/project/hyeongmin-onboarding/src/main/java/kr/co/fastcampus/onboarding/hyeongminonboarding/domain/api/survey/dto/request/SurveyUpdateRequest.java
+++ b/project/hyeongmin-onboarding/src/main/java/kr/co/fastcampus/onboarding/hyeongminonboarding/domain/api/survey/dto/request/SurveyUpdateRequest.java
@@ -23,7 +23,7 @@ public class SurveyUpdateRequest {
     private Long id;
 
     @NotBlank
-    private String name;
+    private String title;
 
     private String description;
 
@@ -36,6 +36,8 @@ public class SurveyUpdateRequest {
     @NoArgsConstructor
     @AllArgsConstructor
     public static class QuestionSurveyRequest {
+
+        private Long id;            // 기존 질문이 있는 경우 재활용할 ID, 신규는 null
 
         @NotBlank
         private String title;

--- a/project/hyeongmin-onboarding/src/main/java/kr/co/fastcampus/onboarding/hyeongminonboarding/domain/api/survey/service/ISurveyService.java
+++ b/project/hyeongmin-onboarding/src/main/java/kr/co/fastcampus/onboarding/hyeongminonboarding/domain/api/survey/service/ISurveyService.java
@@ -2,7 +2,6 @@ package kr.co.fastcampus.onboarding.hyeongminonboarding.domain.api.survey.servic
 
 import kr.co.fastcampus.onboarding.hyeongminonboarding.domain.api.survey.dto.request.SubmitSurveyAnswersRequest;
 import kr.co.fastcampus.onboarding.hyeongminonboarding.domain.api.survey.dto.response.SurveyResponseDto;
-import kr.co.fastcampus.onboarding.hyeongminonboarding.domain.api.survey.dto.request.SubmitAnswerRequest;
 import kr.co.fastcampus.onboarding.hyeongminonboarding.domain.api.survey.dto.request.SurveyCreateRequest;
 import kr.co.fastcampus.onboarding.hyeongminonboarding.domain.api.survey.dto.request.SurveyUpdateRequest;
 import kr.co.fastcampus.onboarding.hyeongminonboarding.domain.api.survey.dto.response.SurveyWithAnswersResponseDto;
@@ -46,5 +45,14 @@ public interface ISurveyService {
      * @param surveyId 조회할 설문조사 ID
      * @return 응답이 포함된 설문조사 상세 정보
      */
-    SurveyWithAnswersResponseDto getSurveyResponses(Long surveyId);
+    SurveyWithAnswersResponseDto getSurveyWithAnswerResponses(Long surveyId);
+
+
+    /**
+     * 설문조사 ID 를 통해 현재버전의 설문조사를 조회합니다.
+     *
+     * @param surveyId 조회할 설문조사 ID
+     * @return 설문조사 상세 정보
+     */
+    SurveyResponseDto getSurveyResponse(Long surveyId);
 }

--- a/project/hyeongmin-onboarding/src/main/java/kr/co/fastcampus/onboarding/hyeongminonboarding/domain/entity/Question.java
+++ b/project/hyeongmin-onboarding/src/main/java/kr/co/fastcampus/onboarding/hyeongminonboarding/domain/entity/Question.java
@@ -5,6 +5,9 @@ import jakarta.persistence.*;
 import kr.co.fastcampus.onboarding.hyeongminonboarding.domain.entity.enums.QuestionType;
 import kr.co.fastcampus.onboarding.hyeongminonboarding.global.entity.base.BaseTimeEntity;
 import lombok.*;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.SoftDelete;
+import org.hibernate.annotations.Where;
 
 import java.util.List;
 
@@ -20,6 +23,8 @@ import java.util.List;
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
+@SQLDelete(sql = "UPDATE question SET deleted = true WHERE id = ?")
+@Where(clause = "deleted = false")
 public class Question extends BaseTimeEntity {
     @Id
     private Long id;
@@ -37,5 +42,9 @@ public class Question extends BaseTimeEntity {
     private QuestionType type;
 
     private boolean required;
+
+    @Column(name = "deleted", nullable = false)
+    @Builder.Default
+    private boolean deleted = false;
 
 }

--- a/project/hyeongmin-onboarding/src/main/java/kr/co/fastcampus/onboarding/hyeongminonboarding/domain/repository/QuestionOptionRepository.java
+++ b/project/hyeongmin-onboarding/src/main/java/kr/co/fastcampus/onboarding/hyeongminonboarding/domain/repository/QuestionOptionRepository.java
@@ -1,5 +1,6 @@
 package kr.co.fastcampus.onboarding.hyeongminonboarding.domain.repository;
 
+import kr.co.fastcampus.onboarding.hyeongminonboarding.domain.entity.Question;
 import kr.co.fastcampus.onboarding.hyeongminonboarding.domain.entity.QuestionOption;
 import org.springframework.data.jpa.repository.JpaRepository;
 
@@ -7,4 +8,10 @@ import java.util.List;
 
 public interface QuestionOptionRepository extends JpaRepository<QuestionOption, Long>, QuestionRepositoryCustom {
     List<QuestionOption> findByQuestionId(Long id);
+
+    void deleteAllByQuestion(Question question);
+
+    void deleteAllByQuestionIn(List<Question> toDelete);
+
+    List<QuestionOption> findAllByQuestionIn(List<Question> questions);
 }

--- a/project/hyeongmin-onboarding/src/main/java/kr/co/fastcampus/onboarding/hyeongminonboarding/domain/repository/QuestionRepository.java
+++ b/project/hyeongmin-onboarding/src/main/java/kr/co/fastcampus/onboarding/hyeongminonboarding/domain/repository/QuestionRepository.java
@@ -3,5 +3,8 @@ package kr.co.fastcampus.onboarding.hyeongminonboarding.domain.repository;
 import kr.co.fastcampus.onboarding.hyeongminonboarding.domain.entity.Question;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface QuestionRepository extends JpaRepository<Question, Long>, QuestionRepositoryCustom {
+    List<Question> findAllBySurveyId(Long surveyId);
 }

--- a/project/hyeongmin-onboarding/src/main/java/kr/co/fastcampus/onboarding/hyeongminonboarding/global/dto/request/BaseRequest.java
+++ b/project/hyeongmin-onboarding/src/main/java/kr/co/fastcampus/onboarding/hyeongminonboarding/global/dto/request/BaseRequest.java
@@ -3,6 +3,7 @@ package kr.co.fastcampus.onboarding.hyeongminonboarding.global.dto.request;
 
 import jakarta.validation.Valid;
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import kr.co.fastcampus.onboarding.hyeongminonboarding.domain.api.survey.dto.request.SubmitSurveyAnswersRequest;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -25,5 +26,9 @@ public class BaseRequest<T> {
     public BaseRequest(T body) {
         this.requestTime = LocalDateTime.now();
         this.body = body;
+    }
+
+    public static <T> BaseRequest<T> of(T body) {
+        return new BaseRequest<>(body);
     }
 }

--- a/project/hyeongmin-onboarding/src/main/java/kr/co/fastcampus/onboarding/hyeongminonboarding/global/entity/base/BaseTimeEntity.java
+++ b/project/hyeongmin-onboarding/src/main/java/kr/co/fastcampus/onboarding/hyeongminonboarding/global/entity/base/BaseTimeEntity.java
@@ -24,4 +24,6 @@ public abstract class BaseTimeEntity {
     private LocalDateTime updatedAt;
 
 
+
+
 }

--- a/project/hyeongmin-onboarding/src/main/java/kr/co/fastcampus/onboarding/hyeongminonboarding/global/exception/enums/ErrorCode.java
+++ b/project/hyeongmin-onboarding/src/main/java/kr/co/fastcampus/onboarding/hyeongminonboarding/global/exception/enums/ErrorCode.java
@@ -9,6 +9,7 @@ public enum ErrorCode {
     INVALID_PAYLOAD(HttpStatus.BAD_REQUEST, "INVALID_PAYLOAD", "잘못된 요청 데이터입니다."),
     VALIDATION_FAILED(HttpStatus.BAD_REQUEST, "VALIDATION_FAILED", "입력값 검증에 실패했습니다."),
     SURVEY_QUESTION_OPTION_EMPTY(HttpStatus.BAD_REQUEST, "SURVEY_QUESTION_OPTION_EMPTY", "질문 타입에 따라 옵션은 필수값입니다. 질문 데이터의 옵션리스트를 확인하세요."),
+    SURVEY_QUESTION_DUPLICATED(HttpStatus.BAD_REQUEST, "SURVEY_QUESTION_DUPLICATED", "같은 질문이 여러번 포함되었습니다."),
     SURVEY_NOT_FOUND(HttpStatus.NOT_FOUND, "SURVEY_NOT_FOUND", "존재하지 않는 설문입니다."),
     RESPONSE_MISMATCH(HttpStatus.UNPROCESSABLE_ENTITY, "RESPONSE_MISMATCH", "응답이 설문 구조와 일치하지 않습니다."),
     INTERNAL_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "INTERNAL_ERROR", "서버 내부 오류가 발생했습니다.");

--- a/project/hyeongmin-onboarding/src/test/java/https/crud.http
+++ b/project/hyeongmin-onboarding/src/test/java/https/crud.http
@@ -47,6 +47,47 @@ Content-Type: application/json
 
 
 
+### Update Survey
+PUT http://localhost:8080/api/survey/1934603757543362560
+Content-Type: application/json
+
+{
+  "body": {
+    "id": 1934603757543362560,
+    "title": "서비스 만족도 조사 (v2)",
+    "description": "2차 개편 반영된 설문내용입니다.",
+    "questions": [
+      {
+        "id": 1934603757585305600,
+        "title": "서비스를 어떻게 알게 되셨나요? (수정)",
+        "detail": "예: 친구 추천, 검색, SNS 등",
+        "type": "SHORT_TEXT",
+        "required": true
+      },
+      {
+        "id": 1934603757593694209,
+        "title": "향후 개선되었으면 하는 부분을 선택해주세요. (수정)",
+        "detail": null,
+        "type": "MULTIPLE_CHOICE",
+        "required": true,
+        "options": [
+          "UI/UX",
+          "성능",
+          "고객지원",
+          "안정성"
+        ]
+      },
+      {
+        "title": "추가 의견이 있으시면 남겨주세요.",
+        "detail": null,
+        "type": "LONG_TEXT",
+        "required": false
+      }
+    ]
+  }
+}
+
+
 ### Submit Survey Answers
 POST http://localhost:8080/api/survey/1934603757543362560/submit
 Content-Type: application/json
@@ -60,24 +101,17 @@ Content-Type: application/json
         "selectedOptionIds": null
       },
       {
-        "questionId": 1934603757585305600,
-        "answerText": "검색엔진에서 발견했습니다.",
-        "selectedOptionIds": null
-      },
-      {
         "questionId": 1934603757593694209,
         "answerText": null,
         "selectedOptionIds": [
-          1934603757597888512,
-          1934603757597888513
+          1934939925854162944,
+          1934939925854162946
         ]
       },
       {
-        "questionId": 1934603757593694210,
-        "answerText": null,
-        "selectedOptionIds": [
-          1934603757597888516
-        ]
+        "questionId": 1934939925803831296,
+        "answerText": "잘 성장 하시길 바랍니다.",
+        "selectedOptionIds": null
       }
     ]
   }
@@ -87,3 +121,9 @@ Content-Type: application/json
 ### Get Survey Responses
 GET http://localhost:8080/api/survey/1934603757543362560/responses
 Accept: application/json
+
+### Get Survey Details
+GET http://localhost:8080/api/survey/1934603757543362560
+Accept: application/json
+
+###

--- a/project/hyeongmin-onboarding/src/test/java/kr/co/fastcampus/onboarding/hyeongminonboarding/functionTest/AssemblerTest.java
+++ b/project/hyeongmin-onboarding/src/test/java/kr/co/fastcampus/onboarding/hyeongminonboarding/functionTest/AssemblerTest.java
@@ -32,14 +32,12 @@ public class AssemblerTest {
 
     @BeforeAll
     static void setUp() {
-        // 1) AssemblerFactory에 우리가 만든 두 개의 Assembler 등록
         List<Assembler<?>> assemblers = List.of(
                 new SurveyResponseDtoAssembler(),
                 new SurveyWithAnswersResponseDtoAssembler(new AnswerSnapshotSerializer(new ObjectMapper()))
         );
         factory = new AssemblerFactory(assemblers);
 
-        // 2) SubmitAnswerRequest 검증용 Validator 세팅
         ValidatorFactory vf = Validation.buildDefaultValidatorFactory();
         validator = vf.getValidator();
     }
@@ -119,11 +117,11 @@ public class AssemblerTest {
         // --- given: SurveyUpdateRequest (id는 이미 존재한다고 가정)
         SurveyUpdateRequest.QuestionSurveyRequest uq =
                 new SurveyUpdateRequest.QuestionSurveyRequest(
-                        "업데이트Q", "업데이트D", QuestionType.SINGLE_CHOICE, true,
+                        null, "업데이트Q", "업데이트D", QuestionType.SINGLE_CHOICE, true,
                         List.of("O1", "O2", "O3"));
         SurveyUpdateRequest req = SurveyUpdateRequest.builder()
                 .id(1L)
-                .name("새설문제목")
+                .title("새설문제목")
                 .description("새설문설명")
                 .questions(List.of(uq))
                 .build();
@@ -131,7 +129,7 @@ public class AssemblerTest {
         // --- when: 기존 Survey Entity 로드 가정 + 요청 반영
         Survey survey = Survey.builder()
                 .id(req.getId())
-                .title(req.getName())
+                .title(req.getTitle())
                 .description(req.getDescription())
                 .version(2)  // 수정 시 버전 증가
                 .build();

--- a/project/hyeongmin-onboarding/src/test/java/kr/co/fastcampus/onboarding/hyeongminonboarding/scenarioTest/ScenarioTest.java
+++ b/project/hyeongmin-onboarding/src/test/java/kr/co/fastcampus/onboarding/hyeongminonboarding/scenarioTest/ScenarioTest.java
@@ -1,0 +1,154 @@
+package kr.co.fastcampus.onboarding.hyeongminonboarding.scenarioTest;
+
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import kr.co.fastcampus.onboarding.hyeongminonboarding.global.dto.request.BaseRequest;
+import kr.co.fastcampus.onboarding.hyeongminonboarding.domain.api.survey.dto.request.SubmitSurveyAnswersRequest;
+import kr.co.fastcampus.onboarding.hyeongminonboarding.domain.api.survey.dto.request.SubmitAnswerRequest;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+public class ScenarioTest {
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Test
+    void fullSurveyLifecycleScenario() throws Exception {
+        // 0. 설문조사를 생성한다.
+        String createJson = "{\n" +
+                "  \"body\": {\n" +
+                "    \"title\": \"Onboarding Survey\",\n" +
+                "    \"description\": \"Project skill evaluation\",\n" +
+                "    \"questions\": [\n" +
+                "      {\"title\": \"Q1?\", \"detail\": \"D1\", \"type\": \"SHORT_TEXT\", \"required\": true},\n" +
+                "      {\"title\": \"Q2?\", \"detail\": null, \"type\": \"SINGLE_CHOICE\", \"required\": false,\n" +
+                "        \"options\": [\"A\",\"B\"]}\n" +
+                "    ]\n" +
+                "  }\n" +
+                "}";
+        MvcResult createResult = mockMvc.perform(post("/api/survey/createSurvey")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(createJson))
+                .andExpect(status().isOk())
+                .andReturn();
+        JsonNode createNode = objectMapper.readTree(createResult.getResponse().getContentAsString());
+        long surveyId = createNode.at("/data/surveyId").asLong();
+
+        JsonNode questionsNode = createNode.at("/data/questions");
+        long q1Id = questionsNode.get(0).get("id").asLong();
+        long q2Id = questionsNode.get(1).get("id").asLong();
+        JsonNode optionsNode = questionsNode.get(1).get("options");
+        long optA = optionsNode.get(0).get("id").asLong();
+        long optB = optionsNode.get(1).get("id").asLong();
+
+        // 1. User A 가 설문조사를 제출한다.
+        SubmitSurveyAnswersRequest answersA = SubmitSurveyAnswersRequest.builder()
+                .answers(List.of(
+                        new SubmitAnswerRequest(q1Id, "Ans A1", null),
+                        new SubmitAnswerRequest(q2Id, null, List.of(optA))
+                )).build();
+        mockMvc.perform(post("/api/survey/" + surveyId + "/submit")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(BaseRequest.of(answersA))))
+                .andExpect(status().isOk());
+
+        // 2. User B 가 설문조사를 제출한다.
+        SubmitSurveyAnswersRequest answersB = SubmitSurveyAnswersRequest.builder()
+                .answers(List.of(
+                        new SubmitAnswerRequest(q1Id, "Ans B1", null),
+                        new SubmitAnswerRequest(q2Id, null, List.of(optB))
+                )).build();
+        mockMvc.perform(post("/api/survey/" + surveyId + "/submit")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(BaseRequest.of(answersB))))
+                .andExpect(status().isOk());
+
+        // 3. 설문조사를 수정한다.
+        ObjectNode bodyNode = objectMapper.createObjectNode();
+        bodyNode.put("id", surveyId);
+        bodyNode.put("title", "Onboarding Survey v2");
+        bodyNode.put("description", "Updated description");
+        ArrayNode questionsArray = objectMapper.createArrayNode();
+        questionsArray.add(objectMapper.createObjectNode()
+                .put("id", q1Id)
+                .put("title", "Q1 updated")
+                .put("detail", "D1 updated")
+                .put("type", "SHORT_TEXT")
+                .put("required", true)
+        );
+        questionsArray.add(objectMapper.createObjectNode()
+                .put("title", "Q3 new")
+                .put("detail", "")
+                .put("type", "LONG_TEXT")
+                .put("required", false)
+        );
+        bodyNode.set("questions", questionsArray);
+
+        ObjectNode rootNode = objectMapper.createObjectNode();
+        rootNode.set("body", bodyNode);
+        String updateJson = objectMapper.writeValueAsString(rootNode);
+
+        mockMvc.perform(put("/api/survey/" + surveyId)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(updateJson))
+                .andExpect(status().isOk());
+
+        // 4. User C 설문조사를 제출한다.
+        MvcResult detailResult = mockMvc.perform(get("/api/survey/" + surveyId)
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andReturn();
+        JsonNode detailNode = objectMapper.readTree(detailResult.getResponse().getContentAsString());
+        JsonNode updatedQuestions = detailNode.at("/data/questions");
+        long q3Id = updatedQuestions.get(1).get("id").asLong();
+        SubmitSurveyAnswersRequest answersC = SubmitSurveyAnswersRequest.builder()
+                .answers(List.of(
+                        new SubmitAnswerRequest(q1Id, "Ans C1", null),
+                        new SubmitAnswerRequest(q3Id, "Ans C3", null)
+                )).build();
+        mockMvc.perform(post("/api/survey/" + surveyId + "/submit")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(BaseRequest.of(answersC))))
+                .andExpect(status().isOk());
+
+        // 5. User D 설문조사를 제출한다.
+        SubmitSurveyAnswersRequest answersD = SubmitSurveyAnswersRequest.builder()
+                .answers(List.of(
+                        new SubmitAnswerRequest(q1Id, "Ans D1", null),
+                        new SubmitAnswerRequest(q3Id, "Ans D3", null)
+                )).build();
+        mockMvc.perform(post("/api/survey/" + surveyId + "/submit")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(BaseRequest.of(answersD))))
+                .andExpect(status().isOk());
+
+        // 수정되기전 설문조사를 제출한 내용과 수정된 후 설문조사를 제출한 내용을 비교 할 수 있어야 한다.
+        MvcResult resResult = mockMvc.perform(get("/api/survey/" + surveyId + "/responses")
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andReturn();
+        JsonNode resNode = objectMapper.readTree(resResult.getResponse().getContentAsString());
+        JsonNode items = resNode.at("/data/responses");
+        assertThat(items.size()).isEqualTo(4);
+        assertThat(resNode.at("/data/title").asText()).isEqualTo("Onboarding Survey v2");
+    }
+}


### PR DESCRIPTION
# 2025-06-17 [v0.0.5]
## feat
- API 개발
  - @PutMapping("/{surveyId}")
    - 설문조사 수정을 위해, Question 엔티티에 deleted 컬럼 추가
    - 설문조사 수정 Request에서 각각의 Question ID를 있으면 받고 없으면 받지 않도록함
    - Question ID 가 존재하면 soft-delete 로 deleted를 수정
    - Question ID 가 존재하지 않으면 새로 생성
    - Question Option은 Delete Insert 전략 사용
  - @GetMapping("/{surveyId})
    - 생성된 설문조사 1개의 양식을 최신상태로 조회하여 볼 수 있도록 새로 생성함
## todo
- Question 을 soft-delete 로 삭제하는 것으로 변경하니, QuestionSnapshot이 의미가 없어졌으므로 리팩토링에서 삭제해야 함
- Assemble 에서 엔티티를 리스트형식으로만 받으니 순환조회하여 ID 값을 맵핑하므로 Map 형식으로 받도록 리팩토링해야 함