### PR TITLE
[2025.06.18]생성API 구현 및 테스트 작성

### DIFF
--- a/project/sumin-onboarding/survey-service/api/src/main/java/com/innercircle/survey/SurveyServiceApplication.java
+++ b/project/sumin-onboarding/survey-service/api/src/main/java/com/innercircle/survey/SurveyServiceApplication.java
@@ -1,4 +1,4 @@
-package com.innercircle.survey.api;
+package com.innercircle.survey;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;

--- a/project/sumin-onboarding/survey-service/api/src/main/java/com/innercircle/survey/api/controller/SurveyController.java
+++ b/project/sumin-onboarding/survey-service/api/src/main/java/com/innercircle/survey/api/controller/SurveyController.java
@@ -11,5 +11,11 @@ import org.springframework.web.bind.annotation.RestController;
 public class SurveyController {
     private final SurveyService surveyService;
 
-
+    @PostMapping
+    public ResponseEntity<?> createSurvey(@RequestBody @Valid SurveyCreateDto request) {
+        UUID surveyId = surveyService.createSurvey(request);
+        return ResponseEntity
+                .status(HttpStatus.CREATED)
+                .body(Map.of("surveyId", surveyId, "message", "설문조사 생성 성공"));
+    }
 }

--- a/project/sumin-onboarding/survey-service/api/src/main/java/com/innercircle/survey/api/controller/SurveyController.java
+++ b/project/sumin-onboarding/survey-service/api/src/main/java/com/innercircle/survey/api/controller/SurveyController.java
@@ -1,9 +1,18 @@
 package com.innercircle.survey.api.controller;
 
 import com.innercircle.survey.application.service.SurveyService;
+import com.innercircle.survey.common.dto.SurveyCreateDto;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+
+import java.util.Map;
+import java.util.UUID;
 
 @RestController
 @RequestMapping("/api/surveys")

--- a/project/sumin-onboarding/survey-service/api/src/test/java/com/innercircle/survey/api/controller/SurveyControllerTest.java
+++ b/project/sumin-onboarding/survey-service/api/src/test/java/com/innercircle/survey/api/controller/SurveyControllerTest.java
@@ -1,0 +1,45 @@
+package com.innercircle.survey.api.controller;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.http.MediaType;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+class SurveyControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Test
+    void createSurveySuccess() throws Exception {
+        String json = """
+                {
+                  "title": "테스트 설문",
+                  "description": "설문 설명입니다.",
+                  "questions": [
+                    {
+                      "title": "당신의 성별은?",
+                      "description": "",
+                      "type": "SINGLE_CHOICE",
+                      "required": true,
+                      "options": ["남자", "여자", "기타"]
+                    }
+                  ]
+                }
+                """;
+
+        mockMvc.perform(post("/api/surveys")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(json))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.surveyId").exists());
+    }
+}

--- a/project/sumin-onboarding/survey-service/application/build.gradle.kts
+++ b/project/sumin-onboarding/survey-service/application/build.gradle.kts
@@ -8,6 +8,9 @@ dependencies {
 
     implementation("org.springframework.boot:spring-boot-starter")
     implementation("org.springframework.boot:spring-boot-starter-validation")
+    implementation("org.springframework.boot:spring-boot-starter-data-jpa")
+
+    testImplementation("org.springframework.boot:spring-boot-starter-test")
 
     compileOnly("org.projectlombok:lombok")
     annotationProcessor("org.projectlombok:lombok")

--- a/project/sumin-onboarding/survey-service/application/src/main/java/com/innercircle/survey/application/service/SurveyService.java
+++ b/project/sumin-onboarding/survey-service/application/src/main/java/com/innercircle/survey/application/service/SurveyService.java
@@ -1,10 +1,41 @@
 package com.innercircle.survey.application.service;
 
 
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 @Service
+@RequiredArgsConstructor
 public class SurveyService {
+    private final SurveyRepository surveyRepository;
 
+    public UUID createSurvey(SurveyCreateDto request) {
+        Survey survey = Survey.builder()
+                .title(request.getTitle())
+                .description(request.getDescription())
+                .build();
+
+        for (QuestionDto q : request.getQuestions()) {
+            Question question = Question.builder()
+                    .title(q.getTitle())
+                    .description(q.getDescription())
+                    .type(q.getType())
+                    .required(q.isRequired())
+                    .survey(survey)
+                    .build();
+
+            if (q.getOptions() != null) {
+                for (String option : q.getOptions()) {
+                    QuestionOption qo = new QuestionOption(option, question);
+                    question.getOptions().add(qo);
+                }
+            }
+
+            survey.getQuestions().add(question);
+        }
+
+        surveyRepository.save(survey);
+        return survey.getId(); // UUID 기준
+    }
 
 }

--- a/project/sumin-onboarding/survey-service/application/src/main/java/com/innercircle/survey/application/service/SurveyService.java
+++ b/project/sumin-onboarding/survey-service/application/src/main/java/com/innercircle/survey/application/service/SurveyService.java
@@ -1,8 +1,16 @@
 package com.innercircle.survey.application.service;
 
 
+import com.innercircle.survey.common.dto.QuestionDto;
+import com.innercircle.survey.common.dto.SurveyCreateDto;
+import com.innercircle.survey.domain.entity.Question;
+import com.innercircle.survey.domain.entity.QuestionOption;
+import com.innercircle.survey.domain.entity.Survey;
+import com.innercircle.survey.domain.repository.SurveyRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+
+import java.util.UUID;
 
 @Service
 @RequiredArgsConstructor

--- a/project/sumin-onboarding/survey-service/common/build.gradle.kts
+++ b/project/sumin-onboarding/survey-service/common/build.gradle.kts
@@ -4,4 +4,7 @@ plugins {
 
 dependencies {
     implementation("org.springframework.boot:spring-boot-starter-validation")
+
+    compileOnly("org.projectlombok:lombok")
+    annotationProcessor("org.projectlombok:lombok")
 }

--- a/project/sumin-onboarding/survey-service/common/src/main/java/com/innercircle/survey/common/dto/QuestionDto.java
+++ b/project/sumin-onboarding/survey-service/common/src/main/java/com/innercircle/survey/common/dto/QuestionDto.java
@@ -1,4 +1,4 @@
-package com.innercircle.survey.api.dto;
+package com.innercircle.survey.common.dto;
 
 import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;

--- a/project/sumin-onboarding/survey-service/common/src/main/java/com/innercircle/survey/common/dto/SurveyCreateDto.java
+++ b/project/sumin-onboarding/survey-service/common/src/main/java/com/innercircle/survey/common/dto/SurveyCreateDto.java
@@ -1,4 +1,4 @@
-package com.innercircle.survey.api.dto;
+package com.innercircle.survey.common.dto;
 
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;

--- a/project/sumin-onboarding/survey-service/domain/build.gradle.kts
+++ b/project/sumin-onboarding/survey-service/domain/build.gradle.kts
@@ -4,4 +4,5 @@ plugins {
 
 dependencies {
     implementation("jakarta.persistence:jakarta.persistence-api:3.1.0")
+    implementation("org.springframework.boot:spring-boot-starter-data-jpa")
 }

--- a/project/sumin-onboarding/survey-service/domain/build.gradle.kts
+++ b/project/sumin-onboarding/survey-service/domain/build.gradle.kts
@@ -5,4 +5,7 @@ plugins {
 dependencies {
     implementation("jakarta.persistence:jakarta.persistence-api:3.1.0")
     implementation("org.springframework.boot:spring-boot-starter-data-jpa")
+
+    compileOnly("org.projectlombok:lombok:1.18.34")
+    annotationProcessor("org.projectlombok:lombok:1.18.34")
 }

--- a/project/sumin-onboarding/survey-service/domain/src/main/java/com/innercircle/survey/domain/entity/Question.java
+++ b/project/sumin-onboarding/survey-service/domain/src/main/java/com/innercircle/survey/domain/entity/Question.java
@@ -1,15 +1,25 @@
 package com.innercircle.survey.domain.entity;
 
 import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 
 @Entity
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
 public class Question {
     //질문 ID(PK)
-    @Id @GeneratedValue
+    @Id
+    @GeneratedValue
     private Long id;
 
     //질문 제목
@@ -30,6 +40,7 @@ public class Question {
     private Survey survey;
 
     //선택 리스트와 1:N
+    @Builder.Default
     @OneToMany(mappedBy = "question", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<QuestionOption> options = new ArrayList<QuestionOption>();
 
@@ -44,6 +55,5 @@ public class Question {
 
     //질문 수정시간
     private LocalDateTime updatedAt;
-
 
 }

--- a/project/sumin-onboarding/survey-service/domain/src/main/java/com/innercircle/survey/domain/entity/QuestionOption.java
+++ b/project/sumin-onboarding/survey-service/domain/src/main/java/com/innercircle/survey/domain/entity/QuestionOption.java
@@ -1,10 +1,18 @@
 package com.innercircle.survey.domain.entity;
 
 import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
 
 @Entity
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
 public class QuestionOption {
     //선택 리스트 ID(PK)
     @Id @GeneratedValue
@@ -28,5 +36,9 @@ public class QuestionOption {
     //선택 리스트 수정시간
     private LocalDateTime updatedAt;
 
+    public QuestionOption(String option, Question question) {
+        this.option = option;
+        this.question = question;
+    }
 
 }

--- a/project/sumin-onboarding/survey-service/domain/src/main/java/com/innercircle/survey/domain/entity/Survey.java
+++ b/project/sumin-onboarding/survey-service/domain/src/main/java/com/innercircle/survey/domain/entity/Survey.java
@@ -1,18 +1,27 @@
 package com.innercircle.survey.domain.entity;
 
 import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.UUID;
 
 @Entity
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
 public class Survey {
     //설문조사 ID(PK)
     @Id
     @GeneratedValue
     @Column(name = "id")
-    private Long id;
+    private UUID id;
 
     //설문조사 제목
     private String title;
@@ -21,6 +30,7 @@ public class Survey {
     private String description;
 
     //설문받을 항목과 1:N
+    @Builder.Default
     @OneToMany(mappedBy = "survey", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Question> questions = new ArrayList<Question>();
 

--- a/project/sumin-onboarding/survey-service/domain/src/main/java/com/innercircle/survey/domain/repository/SurveyRepository.java
+++ b/project/sumin-onboarding/survey-service/domain/src/main/java/com/innercircle/survey/domain/repository/SurveyRepository.java
@@ -1,0 +1,10 @@
+package com.innercircle.survey.domain.repository;
+
+import com.innercircle.survey.domain.entity.Survey;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.UUID;
+
+public interface SurveyRepository extends JpaRepository<Survey, UUID> {
+
+}


### PR DESCRIPTION
## Goal
설문조사를 생성합니다.

## Changes
-설문조사 생성 API (POST /api/surveys) 추가
-SurveyService#createSurvey 로직 구현
-설문/질문/선택지 도메인 및 연관 관계 설정
-테스트 코드(SurveyControllerTest#createSurveySuccess) 작성

## Description
사용자로부터 설문 제목, 설명, 항목 정보를 입력받아 설문을 생성합니다.
각 항목은 질문 제목, 설명, 입력 형태, 필수 여부 및 선택형 항목일 경우 선택지를 포함합니다.
입력 값 유효성 검사를 위해 Bean Validation을 적용하였습니다.
설문 생성 시, 질문 및 선택 항목은 연관된 엔티티로 함께 저장됩니다.

## Additional Context (Optional)
인메모리 H2 DB를 사용하여 테스트 환경에서 빠르게 검증하였습니다.
생성 성공 시 201 Created와 함께 설문 ID를 반환합니다.

## Screenshots/Videos (Optional)

## References (Optional)


