### PR TITLE
수정 api 개발 완료.. 리팩토링 해야함.

### DIFF
--- a/project/junbeom-onboarding/src/main/java/fastcampus_inner_circle/junbeom_onboarding/survey/questionary/adapter/in/SurveyFormController.java
+++ b/project/junbeom-onboarding/src/main/java/fastcampus_inner_circle/junbeom_onboarding/survey/questionary/adapter/in/SurveyFormController.java
@@ -10,8 +10,11 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 
 import fastcampus_inner_circle.junbeom_onboarding.survey.questionary.adapter.in.dto.InsertFormRequest;
+import fastcampus_inner_circle.junbeom_onboarding.survey.questionary.adapter.in.dto.UpdateFormRequest;
 import fastcampus_inner_circle.junbeom_onboarding.survey.questionary.application.service.SurveyFormService;
 
 @RestController
@@ -31,6 +34,21 @@ public class SurveyFormController {
 
         SurveyForm surveyForm = surveyFormService.createSurveyForm(requestDto);
         return ResponseEntity.ok(surveyForm);
+    }
+
+    @PutMapping("/{formId}")
+    public ResponseEntity<?> updateSurvey(
+            @PathVariable Long formId,
+            @Valid @RequestBody UpdateFormRequest requestDto,
+            BindingResult bindingResult
+    ) {
+        if (bindingResult.hasErrors()) {
+            bindingResult.getFieldErrors().forEach(error -> {
+                throw new ContentValidationException(error.getField(), error.getDefaultMessage());
+            });
+        }
+        SurveyForm updatedSurveyForm = surveyFormService.updateSurveyForm(formId, requestDto);
+        return ResponseEntity.ok(updatedSurveyForm);
     }
 
 } 

--- a/project/junbeom-onboarding/src/main/java/fastcampus_inner_circle/junbeom_onboarding/survey/questionary/adapter/in/dto/UpdateFormRequest.java
+++ b/project/junbeom-onboarding/src/main/java/fastcampus_inner_circle/junbeom_onboarding/survey/questionary/adapter/in/dto/UpdateFormRequest.java
@@ -1,0 +1,44 @@
+package fastcampus_inner_circle.junbeom_onboarding.survey.questionary.adapter.in.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class UpdateFormRequest {
+    private String name;
+    private String describe;
+    @Size(min = 1, max = 10, message = "설문 항목은 1개 이상 10개 이하로 입력해야 합니다.")
+    private List<UpdateContentRequest> contents;
+
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class UpdateContentRequest {
+        private Long id; // 기존 항목 수정/삭제 시 필요, 신규 추가 시 null
+        private String name;
+        private String describe;
+        private String type;
+        @JsonProperty("isRequired")
+        private boolean isRequired;
+        private List<UpdateOptionRequest> options;
+
+        @Getter
+        @NoArgsConstructor
+        @AllArgsConstructor
+        @Builder
+        public static class UpdateOptionRequest {
+            private Long id; // 기존 옵션 수정/삭제 시 필요, 신규 추가 시 null
+            private String text;
+        }
+    }
+} 

--- a/project/junbeom-onboarding/src/main/java/fastcampus_inner_circle/junbeom_onboarding/survey/questionary/application/service/SurveyFormService.java
+++ b/project/junbeom-onboarding/src/main/java/fastcampus_inner_circle/junbeom_onboarding/survey/questionary/application/service/SurveyFormService.java
@@ -1,6 +1,7 @@
 package fastcampus_inner_circle.junbeom_onboarding.survey.questionary.application.service;
 
 import fastcampus_inner_circle.junbeom_onboarding.survey.questionary.adapter.in.dto.InsertFormRequest;
+import fastcampus_inner_circle.junbeom_onboarding.survey.questionary.adapter.in.dto.UpdateFormRequest;
 import fastcampus_inner_circle.junbeom_onboarding.survey.questionary.adapter.in.mapper.SurveyFormMapper;
 import fastcampus_inner_circle.junbeom_onboarding.survey.questionary.domain.model.SurveyForm;
 import fastcampus_inner_circle.junbeom_onboarding.survey.questionary.domain.repository.SurveyFormRepository;
@@ -18,9 +19,18 @@ public class SurveyFormService {
         return surveyFormRepository.save(surveyForm);
     }
 
-    public SurveyForm updateSurveyForm(Long id, SurveyForm form) {
-        // 수정 로직, 검증 등
-        // ...
+    public SurveyForm updateSurveyForm(Long id, UpdateFormRequest request) {
+        // 1. 기존 설문 폼 조회
+        SurveyForm form = surveyFormRepository.findById(id)
+            .orElseThrow(() -> new IllegalArgumentException("설문 폼이 존재하지 않습니다."));
+
+        // 2. 이름/설명 수정
+        form.updateNameAndDescribe(request.getName(), request.getDescribe());
+
+        // 3. 문항/옵션 수정
+        form.updateContents(request.getContents());
+
+        // 4. 저장 후 반환
         return surveyFormRepository.save(form);
     }
 

--- a/project/junbeom-onboarding/src/main/java/fastcampus_inner_circle/junbeom_onboarding/survey/questionary/domain/model/SurveyContent.java
+++ b/project/junbeom-onboarding/src/main/java/fastcampus_inner_circle/junbeom_onboarding/survey/questionary/domain/model/SurveyContent.java
@@ -29,4 +29,12 @@ public class SurveyContent {
         this.isRequired = isRequired;
         this.options = options;
     }
+
+    public void update(String name, String describe, SurveyContentType type, boolean isRequired, java.util.List<SurveyContentOption> options) {
+        this.name = name;
+        this.describe = describe;
+        this.type = type;
+        this.isRequired = isRequired;
+        this.options = options;
+    }
 }

--- a/project/junbeom-onboarding/src/main/java/fastcampus_inner_circle/junbeom_onboarding/survey/questionary/domain/model/SurveyContentOption.java
+++ b/project/junbeom-onboarding/src/main/java/fastcampus_inner_circle/junbeom_onboarding/survey/questionary/domain/model/SurveyContentOption.java
@@ -24,4 +24,8 @@ public class SurveyContentOption {
     public int hashCode() {
         return Objects.hash(text); // text만 포함
     }
+
+    public void update(String text) {
+        this.text = text;
+    }
 }

--- a/project/junbeom-onboarding/src/main/java/fastcampus_inner_circle/junbeom_onboarding/survey/questionary/domain/model/SurveyForm.java
+++ b/project/junbeom-onboarding/src/main/java/fastcampus_inner_circle/junbeom_onboarding/survey/questionary/domain/model/SurveyForm.java
@@ -18,4 +18,76 @@ public class SurveyForm {
     private String describe;
     private LocalDateTime createAt;
     private List<SurveyContent> contents;
+
+    public void updateNameAndDescribe(String name, String describe) {
+        this.name = name;
+        this.describe = describe;
+    }
+
+    public void updateContents(java.util.List<fastcampus_inner_circle.junbeom_onboarding.survey.questionary.adapter.in.dto.UpdateFormRequest.UpdateContentRequest> contentRequests) {
+        if (contentRequests == null) {
+            this.contents = java.util.Collections.emptyList();
+            return;
+        }
+        java.util.Map<Long, SurveyContent> existingContentMap = new java.util.HashMap<>();
+        if (this.contents != null) {
+            for (SurveyContent c : this.contents) {
+                if (c.getId() != null) existingContentMap.put(c.getId(), c);
+            }
+        }
+        java.util.List<SurveyContent> updatedContents = new java.util.ArrayList<>();
+        for (fastcampus_inner_circle.junbeom_onboarding.survey.questionary.adapter.in.dto.UpdateFormRequest.UpdateContentRequest req : contentRequests) {
+            java.util.List<SurveyContentOption> updatedOptions = new java.util.ArrayList<>();
+            if (req.getOptions() != null) {
+                java.util.Map<Long, SurveyContentOption> existingOptionMap = new java.util.HashMap<>();
+                SurveyContent existingContent = req.getId() != null ? existingContentMap.get(req.getId()) : null;
+                if (existingContent != null && existingContent.getOptions() != null) {
+                    for (SurveyContentOption o : existingContent.getOptions()) {
+                        if (o.getId() != null) existingOptionMap.put(o.getId(), o);
+                    }
+                }
+                for (fastcampus_inner_circle.junbeom_onboarding.survey.questionary.adapter.in.dto.UpdateFormRequest.UpdateContentRequest.UpdateOptionRequest optReq : req.getOptions()) {
+                    if (optReq.getId() == null) {
+                        // 신규 옵션
+                        updatedOptions.add(SurveyContentOption.builder()
+                                .text(optReq.getText())
+                                .build());
+                    } else if (existingOptionMap.containsKey(optReq.getId())) {
+                        // 기존 옵션 수정
+                        SurveyContentOption existOpt = existingOptionMap.get(optReq.getId());
+                        existOpt.update(optReq.getText());
+                        updatedOptions.add(existOpt);
+                        existingOptionMap.remove(optReq.getId());
+                    }
+                    // else: 잘못된 id는 무시
+                }
+                // existingOptionMap에 남은 값들은 삭제 대상(아무 처리 안 함)
+            }
+            if (req.getId() == null) {
+                // 신규 문항
+                updatedContents.add(SurveyContent.builder()
+                        .name(req.getName())
+                        .describe(req.getDescribe())
+                        .type(fastcampus_inner_circle.junbeom_onboarding.survey.questionary.adapter.out.entity.SurveyContentType.valueOf(req.getType()))
+                        .isRequired(req.isRequired())
+                        .options(updatedOptions)
+                        .build());
+            } else if (existingContentMap.containsKey(req.getId())) {
+                // 기존 문항 수정
+                SurveyContent existContent = existingContentMap.get(req.getId());
+                existContent.update(
+                        req.getName(),
+                        req.getDescribe(),
+                        fastcampus_inner_circle.junbeom_onboarding.survey.questionary.adapter.out.entity.SurveyContentType.valueOf(req.getType()),
+                        req.isRequired(),
+                        updatedOptions
+                );
+                updatedContents.add(existContent);
+                existingContentMap.remove(req.getId());
+            }
+            // else: 잘못된 id는 무시
+        }
+        // existingContentMap에 남은 값들은 삭제 대상(아무 처리 안 함)
+        this.contents = updatedContents;
+    }
 }

--- a/project/junbeom-onboarding/src/test/java/fastcampus_inner_circle/junbeom_onboarding/survey/answer/adapter/in/AnswerControllerQueryIntegrationTest.java
+++ b/project/junbeom-onboarding/src/test/java/fastcampus_inner_circle/junbeom_onboarding/survey/answer/adapter/in/AnswerControllerQueryIntegrationTest.java
@@ -48,5 +48,23 @@ class AnswerControllerQueryIntegrationTest {
         );
         System.out.println("파싱된 AnswerResponse 목록:");
         responses.forEach(System.out::println);
+
+        // === 실제 데이터 검증 ===
+        // 예시: 첫 번째 응답의 formId, formName, answers 필드 검증
+        assert !responses.isEmpty();
+        AnswerResponse answer = responses.get(0);
+        org.assertj.core.api.Assertions.assertThat(answer.getFormId()).isEqualTo(1L);
+        org.assertj.core.api.Assertions.assertThat(answer.getFormName()).isNotBlank();
+        org.assertj.core.api.Assertions.assertThat(answer.getAnswers()).isNotEmpty();
+        // 첫 번째 문항 검증
+        AnswerResponse.AnswerDetail first = answer.getAnswers().get(0);
+        org.assertj.core.api.Assertions.assertThat(first.getContentId()).isEqualTo(1L);
+        org.assertj.core.api.Assertions.assertThat(first.getContentName()).isNotBlank();
+        // 두 번째 문항(객관식) 옵션 검증 (옵션이 있을 경우)
+        if (answer.getAnswers().size() > 1 && answer.getAnswers().get(1).getOptions() != null && !answer.getAnswers().get(1).getOptions().isEmpty()) {
+            AnswerResponse.AnswerOption option = answer.getAnswers().get(1).getOptions().get(0);
+            org.assertj.core.api.Assertions.assertThat(option.getOptionId()).isNotNull();
+            org.assertj.core.api.Assertions.assertThat(option.getOptionName()).isNotBlank();
+        }
     }
 } 

--- a/project/junbeom-onboarding/src/test/java/fastcampus_inner_circle/junbeom_onboarding/survey/questionary/adapter/in/SurveyFormControllerTest.java
+++ b/project/junbeom-onboarding/src/test/java/fastcampus_inner_circle/junbeom_onboarding/survey/questionary/adapter/in/SurveyFormControllerTest.java
@@ -8,7 +8,6 @@ import fastcampus_inner_circle.junbeom_onboarding.survey.questionary.application
 import fastcampus_inner_circle.junbeom_onboarding.survey.questionary.domain.model.SurveyForm;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.BeforeEach;
-
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
@@ -26,7 +25,25 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-class SurveyFormControllerTest {
+import fastcampus_inner_circle.junbeom_onboarding.survey.answer.adapter.in.dto.AnswerRequest;
+import fastcampus_inner_circle.junbeom_onboarding.survey.answer.adapter.in.dto.AnswerResponse;
+import fastcampus_inner_circle.junbeom_onboarding.survey.questionary.adapter.in.dto.InsertContentRequest;
+import fastcampus_inner_circle.junbeom_onboarding.survey.questionary.adapter.in.dto.UpdateFormRequest;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@Transactional
+public class SurveyFormControllerTest {
 
     @Mock
     private SurveyFormService surveyFormService;
@@ -34,7 +51,9 @@ class SurveyFormControllerTest {
     @InjectMocks
     private SurveyFormController surveyFormController;
 
+    @Autowired
     private MockMvc mockMvc;
+    @Autowired
     private ObjectMapper objectMapper;
 
     @BeforeEach
@@ -143,8 +162,63 @@ class SurveyFormControllerTest {
                 .andExpect(jsonPath("$.message").value("contents: 설문 항목은 1개 이상 10개 이하로 입력해야 합니다."));
     }
 
+    @Test
+    void 설문_폼_수정_후_기존_응답_보존_테스트() throws Exception {
+        // 1. 설문 폼 생성
+        InsertFormRequest insertForm = InsertFormRequest.builder()
+                .name("설문1")
+                .describe("설명1")
+                .contents(List.of(
+                        InsertContentRequest.builder().name("문항1").describe("desc1").type("SHORT_TEXT").isRequired(true).options(List.of()).build(),
+                        InsertContentRequest.builder().name("문항2").describe("desc2").type("SINGLE_SELECT").isRequired(false).options(List.of("옵션1", "옵션2")).build()
+                ))
+                .build();
+        String formRes = mockMvc.perform(post("/api/surveys")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(insertForm)))
+                .andExpect(status().isOk())
+                .andReturn().getResponse().getContentAsString();
+        Long formId = objectMapper.readTree(formRes).get("id").asLong();
 
+        // 2. 설문 응답 제출
+        AnswerRequest.AnswerDetail answer1 = new AnswerRequest.AnswerDetail();
+        answer1.setContentId(1L); answer1.setContentName("문항1"); answer1.setContentDescribe("desc1"); answer1.setType("SHORT_TEXT"); answer1.setValue("답변1");
+        AnswerRequest.AnswerDetail answer2 = new AnswerRequest.AnswerDetail();
+        answer2.setContentId(2L); answer2.setContentName("문항2"); answer2.setContentDescribe("desc2"); answer2.setType("SINGLE_SELECT");
+        AnswerRequest.AnswerDetailOptions option = new AnswerRequest.AnswerDetailOptions();
+        option.setOptionId(1L);
+        option.setText("옵션1");
+        answer2.setOptions(List.of(option));
+        AnswerRequest answerRequest = new AnswerRequest();
+        answerRequest.setFormId(formId); answerRequest.setFormName("설문1"); answerRequest.setAnswers(List.of(answer1, answer2));
+        String answerRes = mockMvc.perform(post("/api/answers")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(answerRequest)))
+                .andExpect(status().isOk())
+                .andReturn().getResponse().getContentAsString();
+        Long answerId = objectMapper.readTree(answerRes).get("answerId").asLong();
 
+        // 3. 설문 폼 수정 (문항1 이름 변경, 문항2 삭제, 문항3 추가)
+        UpdateFormRequest.UpdateContentRequest updated1 = UpdateFormRequest.UpdateContentRequest.builder()
+                .id(1L).name("문항1-수정").describe("desc1").type("SHORT_TEXT").isRequired(true).options(List.of()).build();
+        UpdateFormRequest.UpdateContentRequest newContent = UpdateFormRequest.UpdateContentRequest.builder()
+                .name("문항3").describe("desc3").type("LONG_TEXT").isRequired(false).options(List.of()).build();
+        UpdateFormRequest updateForm = UpdateFormRequest.builder()
+                .name("설문1-수정").describe("설명1-수정")
+                .contents(List.of(updated1, newContent))
+                .build();
+        mockMvc.perform(put("/api/surveys/" + formId)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(updateForm)))
+                .andExpect(status().isOk());
 
-
+        // 4. 기존 응답 조회
+        String answerGetRes = mockMvc.perform(get("/api/answers/" + answerId))
+                .andExpect(status().isOk())
+                .andReturn().getResponse().getContentAsString();
+        AnswerResponse answerResponse = objectMapper.readValue(answerGetRes, AnswerResponse.class);
+        assertThat(answerResponse.getFormId()).isEqualTo(formId);
+        assertThat(answerResponse.getAnswers()).extracting("contentName").contains("문항1"); // 기존 응답의 문항명은 변경 전 값
+        assertThat(answerResponse.getAnswers()).extracting("contentName").doesNotContain("문항3"); // 신규 문항 없음
+    }
 }


### PR DESCRIPTION
## Goal
설문 폼(설문조사) 수정 API를 개발하여, 설문 제목/설명/항목(질문) 및 옵션(선택지)의 추가, 수정, 삭제를 지원합니다.
설문 폼이 변경되어도 기존 응답(Answer) 데이터가 안전하게 보존되도록 구현합니다.
<!-- Describe the goal of this PR -->

## Changes
PUT /api/surveys/{formId} 설문 폼 수정 API 엔드포인트 추가
설문 폼 수정 요청 DTO(UpdateFormRequest 및 내부 클래스) 생성
SurveyFormController, SurveyFormService, 도메인/엔티티/매퍼 수정
문항/옵션의 추가, 수정, 삭제 로직 구현 (id 기반 비교)
기존 응답 데이터(Answer, AnswerDetail 등)는 절대 삭제/수정하지 않도록 설계
통합 테스트: 폼 수정 후에도 기존 응답이 보존되는지 검증
<!-- Describe the changes made in this PR -->

## Description
설문 폼 수정 요청 시, 제목/설명/문항/옵션을 한 번에 수정할 수 있습니다.
문항/옵션은 id가 없으면 신규 추가, 있으면 수정, 요청에 없는 기존 항목/옵션은 삭제 처리됩니다.
SurveyForm, SurveyContent, SurveyContentOption 도메인에 update 메서드 추가
서비스 계층에서 도메인 메서드를 활용해 비즈니스 로직 구현
기존 응답 데이터는 폼 변경과 무관하게 안전하게 보존됩니다.
통합 테스트에서 폼 수정 후에도 기존 응답이 정상적으로 조회되는지 검증
<!-- Describe the changes made in this PR -->

## Additional Context (Optional)
설문 폼 생성/수정/조회/응답 제출/조회 등 전체 API의 일관성 및 데이터 무결성 보장
폼-응답 완전 분리 구조로 설계되어, 실무적 확장성과 유지보수성 향상
<!-- Add any additional context or information here -->

## Screenshots/Videos (Optional)

<!-- Add screenshots if applicable -->

## References (Optional)

<!-- Add references like GitHub Issue, related PRs, etc. -->

