### PR TITLE
[2025.06.21]설문조사 수정 및 응답 제출 API 구현

### DIFF
--- a/project/sumin-onboarding/.idea/.gitignore
+++ b/project/sumin-onboarding/.idea/.gitignore
@@ -1,0 +1,10 @@
+# 디폴트 무시된 파일
+/shelf/
+/workspace.xml
+# 에디터 기반 HTTP 클라이언트 요청
+/httpRequests/
+# 환경에 따라 달라지는 Maven 홈 디렉터리
+/mavenHomeManager.xml
+# Datasource local storage ignored files
+/dataSources/
+/dataSources.local.xml

--- a/project/sumin-onboarding/.idea/compiler.xml
+++ b/project/sumin-onboarding/.idea/compiler.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="CompilerConfiguration">
+    <annotationProcessing>
+      <profile name="Gradle Imported" enabled="true">
+        <outputRelativeToContentRoot value="true" />
+        <processorPath useClasspath="false">
+          <entry name="$USER_HOME$/.gradle/caches/modules-2/files-2.1/org.projectlombok/lombok/1.18.38/57f8f5e02e92a30fd21b80cbd426a4172b5f8e29/lombok-1.18.38.jar" />
+        </processorPath>
+        <module name="survey-service.api.main" />
+        <module name="survey-service.common.main" />
+        <module name="survey-service.application.main" />
+      </profile>
+      <profile name="Gradle Imported" enabled="true">
+        <outputRelativeToContentRoot value="true" />
+        <processorPath useClasspath="false">
+          <entry name="$USER_HOME$/.gradle/caches/modules-2/files-2.1/org.projectlombok/lombok/1.18.34/ec547ef414ab1d2c040118fb9c1c265ada63af14/lombok-1.18.34.jar" />
+        </processorPath>
+        <module name="survey-service.domain.main" />
+      </profile>
+    </annotationProcessing>
+  </component>
+  <component name="JavacSettings">
+    <option name="ADDITIONAL_OPTIONS_OVERRIDE">
+      <module name="survey-service.api" options="-parameters" />
+      <module name="survey-service.api.main" options="-parameters" />
+      <module name="survey-service.api.test" options="-parameters" />
+      <module name="survey-service.application" options="-parameters" />
+      <module name="survey-service.application.main" options="-parameters" />
+      <module name="survey-service.application.test" options="-parameters" />
+      <module name="survey-service.common" options="-parameters" />
+      <module name="survey-service.common.main" options="-parameters" />
+      <module name="survey-service.common.test" options="-parameters" />
+      <module name="survey-service.domain" options="-parameters" />
+      <module name="survey-service.domain.main" options="-parameters" />
+      <module name="survey-service.domain.test" options="-parameters" />
+    </option>
+  </component>
+</project>

--- a/project/sumin-onboarding/.idea/dataSources.xml
+++ b/project/sumin-onboarding/.idea/dataSources.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="DataSourceManagerImpl" format="xml" multifile-model="true">
+    <data-source source="LOCAL" name="testdb" uuid="f9ebf450-cc14-4870-94d5-fa368e6eb64f">
+      <driver-ref>h2.unified</driver-ref>
+      <synchronize>true</synchronize>
+      <imported>true</imported>
+      <remarks>$PROJECT_DIR$/survey-service/api/src/main/resources/application.yml</remarks>
+      <jdbc-driver>org.h2.Driver</jdbc-driver>
+      <jdbc-url>jdbc:h2:mem:testdb</jdbc-url>
+      <jdbc-additional-properties>
+        <property name="com.intellij.clouds.kubernetes.db.host.port" />
+        <property name="com.intellij.clouds.kubernetes.db.enabled" value="false" />
+        <property name="com.intellij.clouds.kubernetes.db.resource.type" value="Deployment" />
+        <property name="com.intellij.clouds.kubernetes.db.container.port" />
+      </jdbc-additional-properties>
+      <working-dir>$ProjectFileDir$</working-dir>
+    </data-source>
+    <data-source source="LOCAL" name="testdb" uuid="c9afd8cb-6605-4062-9503-e62c5700ef4c">
+      <driver-ref>h2.unified</driver-ref>
+      <synchronize>true</synchronize>
+      <imported>true</imported>
+      <remarks>$PROJECT_DIR$/survey-service/api/src/main/resources/application.yml</remarks>
+      <jdbc-driver>org.h2.Driver</jdbc-driver>
+      <jdbc-url>jdbc:h2:mem:testdb</jdbc-url>
+      <jdbc-additional-properties>
+        <property name="com.intellij.clouds.kubernetes.db.host.port" />
+        <property name="com.intellij.clouds.kubernetes.db.enabled" value="false" />
+        <property name="com.intellij.clouds.kubernetes.db.container.port" />
+      </jdbc-additional-properties>
+      <working-dir>$ProjectFileDir$</working-dir>
+    </data-source>
+  </component>
+</project>

--- a/project/sumin-onboarding/.idea/gradle.xml
+++ b/project/sumin-onboarding/.idea/gradle.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="GradleMigrationSettings" migrationVersion="1" />
+  <component name="GradleSettings">
+    <option name="linkedExternalProjectsSettings">
+      <GradleProjectSettings>
+        <option name="externalProjectPath" value="$PROJECT_DIR$/survey-service" />
+        <option name="gradleJvm" value="temurin-17" />
+        <option name="modules">
+          <set>
+            <option value="$PROJECT_DIR$/survey-service" />
+            <option value="$PROJECT_DIR$/survey-service/api" />
+            <option value="$PROJECT_DIR$/survey-service/application" />
+            <option value="$PROJECT_DIR$/survey-service/common" />
+            <option value="$PROJECT_DIR$/survey-service/domain" />
+          </set>
+        </option>
+      </GradleProjectSettings>
+    </option>
+  </component>
+</project>

--- a/project/sumin-onboarding/.idea/misc.xml
+++ b/project/sumin-onboarding/.idea/misc.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ExternalStorageConfigurationManager" enabled="true" />
+  <component name="FrameworkDetectionExcludesConfiguration">
+    <file type="web" url="file://$PROJECT_DIR$/survey-service" />
+  </component>
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_24" project-jdk-name="temurin-17" project-jdk-type="JavaSDK">
+    <output url="file://$PROJECT_DIR$/out" />
+  </component>
+</project>

--- a/project/sumin-onboarding/.idea/modules.xml
+++ b/project/sumin-onboarding/.idea/modules.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectModuleManager">
+    <modules>
+      <module fileurl="file://$PROJECT_DIR$/.idea/sumin-onboarding.iml" filepath="$PROJECT_DIR$/.idea/sumin-onboarding.iml" />
+      <module fileurl="file://$PROJECT_DIR$/.idea/modules/common/survey-service.common.main.iml" filepath="$PROJECT_DIR$/.idea/modules/common/survey-service.common.main.iml" />
+      <module fileurl="file://$PROJECT_DIR$/.idea/modules/domain/survey-service.domain.main.iml" filepath="$PROJECT_DIR$/.idea/modules/domain/survey-service.domain.main.iml" />
+    </modules>
+  </component>
+</project>

--- a/project/sumin-onboarding/.idea/modules/common/survey-service.common.main.iml
+++ b/project/sumin-onboarding/.idea/modules/common/survey-service.common.main.iml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module version="4">
+  <component name="AdditionalModuleElements">
+    <content url="file://$MODULE_DIR$/../../../survey-service/common/build/generated/sources/annotationProcessor/java/main">
+      <sourceFolder url="file://$MODULE_DIR$/../../../survey-service/common/build/generated/sources/annotationProcessor/java/main" isTestSource="false" generated="true" />
+    </content>
+  </component>
+</module>

--- a/project/sumin-onboarding/.idea/modules/domain/survey-service.domain.main.iml
+++ b/project/sumin-onboarding/.idea/modules/domain/survey-service.domain.main.iml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module version="4">
+  <component name="AdditionalModuleElements">
+    <content url="file://$MODULE_DIR$/../../../survey-service/domain/build/generated/sources/annotationProcessor/java/main">
+      <sourceFolder url="file://$MODULE_DIR$/../../../survey-service/domain/build/generated/sources/annotationProcessor/java/main" isTestSource="false" generated="true" />
+    </content>
+  </component>
+</module>

--- a/project/sumin-onboarding/.idea/sumin-onboarding.iml
+++ b/project/sumin-onboarding/.idea/sumin-onboarding.iml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="JAVA_MODULE" version="4">
+  <component name="NewModuleRootManager" inherit-compiler-output="true">
+    <exclude-output />
+    <content url="file://$MODULE_DIR$" />
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+</module>

--- a/project/sumin-onboarding/.idea/vcs.xml
+++ b/project/sumin-onboarding/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="$PROJECT_DIR$/../.." vcs="Git" />
+  </component>
+</project>

--- a/project/sumin-onboarding/survey-service/api/build.gradle.kts
+++ b/project/sumin-onboarding/survey-service/api/build.gradle.kts
@@ -12,6 +12,7 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-starter")
     implementation("org.springframework.boot:spring-boot-starter-web")
     implementation("org.springframework.boot:spring-boot-starter-validation")
+    implementation("org.springframework.boot:spring-boot-starter-data-jpa")
 
     compileOnly("org.projectlombok:lombok")
     annotationProcessor("org.projectlombok:lombok")

--- a/project/sumin-onboarding/survey-service/api/src/main/java/com/innercircle/survey/api/advice/GlobalExceptionHandler.java
+++ b/project/sumin-onboarding/survey-service/api/src/main/java/com/innercircle/survey/api/advice/GlobalExceptionHandler.java
@@ -1,0 +1,42 @@
+package com.innercircle.survey.api.advice;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    //유효성 검증 실패 시
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<?> handleValidationException(MethodArgumentNotValidException ex) {
+        Map<String, String> errors = new HashMap<>();
+        ex.getBindingResult().getFieldErrors().forEach(error ->
+                errors.put(error.getField(), error.getDefaultMessage())
+        );
+
+        return ResponseEntity.badRequest().body(Map.of(
+                "message", "입력값이 유효하지 않습니다.",
+                "errors", errors
+        ));
+    }
+
+    //잘못된 인자
+    @ExceptionHandler(IllegalArgumentException.class)
+    public ResponseEntity<?> handleIllegalArgument(IllegalArgumentException ex) {
+        return ResponseEntity.badRequest().body(Map.of(
+                "message", ex.getMessage()
+        ));
+    }
+
+    //기타
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<?> handleException(Exception ex) {
+        return ResponseEntity.internalServerError().body(Map.of(
+                "message", "알 수 없는 서버 오류가 발생했습니다."
+        ));
+    }
+}

--- a/project/sumin-onboarding/survey-service/api/src/main/java/com/innercircle/survey/api/controller/SurveyController.java
+++ b/project/sumin-onboarding/survey-service/api/src/main/java/com/innercircle/survey/api/controller/SurveyController.java
@@ -2,14 +2,12 @@ package com.innercircle.survey.api.controller;
 
 import com.innercircle.survey.application.service.SurveyService;
 import com.innercircle.survey.common.dto.SurveyCreateDto;
+import com.innercircle.survey.common.dto.SurveyUpdateDto;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.Map;
 import java.util.UUID;
@@ -26,5 +24,12 @@ public class SurveyController {
         return ResponseEntity
                 .status(HttpStatus.CREATED)
                 .body(Map.of("surveyId", surveyId, "message", "설문조사 생성 성공"));
+    }
+
+    @PutMapping("/{surveyId}")
+    public ResponseEntity<?> updateSurvey(@PathVariable UUID surveyId,
+                                          @Valid @RequestBody SurveyUpdateDto request) {
+        surveyService.updateSurvey(surveyId, request);
+        return ResponseEntity.ok().body("설문조사 수정 성공");
     }
 }

--- a/project/sumin-onboarding/survey-service/api/src/main/java/com/innercircle/survey/api/controller/SurveyController.java
+++ b/project/sumin-onboarding/survey-service/api/src/main/java/com/innercircle/survey/api/controller/SurveyController.java
@@ -30,6 +30,6 @@ public class SurveyController {
     public ResponseEntity<?> updateSurvey(@PathVariable UUID surveyId,
                                           @Valid @RequestBody SurveyUpdateDto request) {
         surveyService.updateSurvey(surveyId, request);
-        return ResponseEntity.ok().body("설문조사 수정 성공");
+        return ResponseEntity.ok().body(Map.of("message","설문조사 수정 성공"));
     }
 }

--- a/project/sumin-onboarding/survey-service/api/src/main/java/com/innercircle/survey/api/controller/SurveyResponseController.java
+++ b/project/sumin-onboarding/survey-service/api/src/main/java/com/innercircle/survey/api/controller/SurveyResponseController.java
@@ -1,0 +1,29 @@
+package com.innercircle.survey.api.controller;
+
+import com.innercircle.survey.application.service.SurveyResponseService;
+import com.innercircle.survey.common.dto.SurveyResponseDto;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.UUID;
+
+@RestController
+@RequestMapping("/api/surveys")
+@RequiredArgsConstructor
+public class SurveyResponseController {
+
+    private final SurveyResponseService surveyResponseService;
+
+    @PostMapping("/{surveyId}/responses")
+    public ResponseEntity<Void> submitSurveyResponse(
+            @PathVariable UUID surveyId,
+            @Valid @RequestBody SurveyResponseDto request
+    ) {
+        request.setSurveyId(surveyId);
+
+        surveyResponseService.submitResponse(request);
+        return ResponseEntity.ok().build();
+    }
+}

--- a/project/sumin-onboarding/survey-service/api/src/main/resources/application.yml
+++ b/project/sumin-onboarding/survey-service/api/src/main/resources/application.yml
@@ -1,12 +1,12 @@
 spring:
   datasource:
-    url: jdbc:h2:mem:testdb
+    url: jdbc:h2:file:~/survey-db
     driver-class-name: org.h2.Driver
     username: sa
     password:
   jpa:
     hibernate:
-      ddl-auto: create-drop
+      ddl-auto: update
     show-sql: true
     properties:
       hibernate:

--- a/project/sumin-onboarding/survey-service/api/src/test/java/com/innercircle/survey/api/controller/SurveyControllerTest.java
+++ b/project/sumin-onboarding/survey-service/api/src/test/java/com/innercircle/survey/api/controller/SurveyControllerTest.java
@@ -1,13 +1,24 @@
 package com.innercircle.survey.api.controller;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.innercircle.survey.common.dto.QuestionUpdateDto;
+import com.innercircle.survey.common.dto.SurveyUpdateDto;
+import com.innercircle.survey.domain.entity.Question;
+import com.innercircle.survey.domain.entity.Survey;
+import com.innercircle.survey.domain.repository.SurveyRepository;
 import org.junit.jupiter.api.Test;
-import org.springframework.http.MediaType;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.util.Pair;
+import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 
+import java.util.List;
+import java.util.UUID;
+
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -17,6 +28,12 @@ class SurveyControllerTest {
 
     @Autowired
     private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Autowired
+    private SurveyRepository surveyRepository;
 
     @Test
     void createSurveySuccess() throws Exception {
@@ -41,5 +58,61 @@ class SurveyControllerTest {
                         .content(json))
                 .andExpect(status().isCreated())
                 .andExpect(jsonPath("$.surveyId").exists());
+    }
+
+    @Test
+    void updateSurvey_success() throws Exception {
+        Pair<UUID, UUID> ids  = createDummySurveyAndReturnId(); //더미 설문조사
+        UUID existingSurveyId = ids.getFirst();
+        UUID existingQuestionId = ids.getSecond();
+
+        SurveyUpdateDto updateDto = SurveyUpdateDto.builder()
+                .title("수정된 설문 제목")
+                .description("수정된 설명")
+                .questions(List.of(
+                        QuestionUpdateDto.builder()
+                                .questionId(existingQuestionId)  // 기존 질문 수정
+                                .title("질문1 수정됨")
+                                .description("설명1")
+                                .type("SINGLE_CHOICE")
+                                .required(true)
+                                .options(List.of("옵션1", "옵션2"))
+                                .build(),
+                        QuestionUpdateDto.builder()
+                                .title("새로운 질문")
+                                .description("새 설명")
+                                .type("TEXT")
+                                .required(false)
+                                .build()
+                ))
+                .build();
+
+        String json = objectMapper.writeValueAsString(updateDto);
+
+        mockMvc.perform(put("/api/surveys/" + existingSurveyId)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(json))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.message").value("설문조사 수정 성공"));
+    }
+
+    private Pair<UUID, UUID> createDummySurveyAndReturnId() {
+        Survey survey = Survey.builder()
+                .title("테스트 설문")
+                .description("테스트 설명")
+                .build();
+
+        Question question = Question.builder()
+                .title("당신의 성별은?")
+                .description("")
+                .type("SINGLE_CHOICE")
+                .required(true)
+                .survey(survey)
+                .build();
+
+        survey.addQuestion(question);
+
+        surveyRepository.save(survey);
+        return Pair.of(survey.getId(), question.getId());
     }
 }

--- a/project/sumin-onboarding/survey-service/application/build.gradle.kts
+++ b/project/sumin-onboarding/survey-service/application/build.gradle.kts
@@ -12,6 +12,8 @@ dependencies {
 
     testImplementation("org.springframework.boot:spring-boot-starter-test")
 
+    implementation("com.fasterxml.jackson.core:jackson-databind:2.15.2")
+
     compileOnly("org.projectlombok:lombok")
     annotationProcessor("org.projectlombok:lombok")
 }

--- a/project/sumin-onboarding/survey-service/application/src/main/java/com/innercircle/survey/application/service/SurveyResponseService.java
+++ b/project/sumin-onboarding/survey-service/application/src/main/java/com/innercircle/survey/application/service/SurveyResponseService.java
@@ -3,6 +3,7 @@ package com.innercircle.survey.application.service;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.innercircle.survey.common.dto.AnswerDto;
+import com.innercircle.survey.common.dto.QuestionSnapshotDto;
 import com.innercircle.survey.common.dto.SurveyResponseDto;
 import com.innercircle.survey.domain.entity.Question;
 import com.innercircle.survey.domain.entity.Survey;
@@ -13,6 +14,7 @@ import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import java.util.List;
 import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
@@ -27,33 +29,50 @@ public class SurveyResponseService {
     private final ObjectMapper objectMapper;
 
     public void submitResponse(SurveyResponseDto request) {
-        // 1. 설문 존재 여부 확인
-        Survey survey = surveyRepository.findById(request.getSurveyId())
-                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 설문입니다."));
+        try {
+            //1.설문 존재 여부 확인
+            Survey survey = surveyRepository.findById(request.getSurveyId())
+                    .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 설문입니다."));
 
-        // 2. 질문 ID 유효성 검증
-        Set<UUID> validQuestionIds = survey.getQuestions().stream()
-                .map(Question::getId)
-                .collect(Collectors.toSet());
-
-        for (AnswerDto answer : request.getAnswers()) {
-            UUID qid = UUID.fromString(answer.getQuestionId());
-            if (!validQuestionIds.contains(qid)) {
-                throw new IllegalArgumentException("유효하지 않은 질문 ID입니다: " + qid);
+            //2.질문 ID 유효성 검증
+            Set<UUID> validQuestionIds = survey.getQuestions().stream()
+                    .map(Question::getId)
+                    .collect(Collectors.toSet());
+            System.out.println("요청 받은 surveyId = " + request.getSurveyId());
+            for (AnswerDto answer : request.getAnswers()) {
+                System.out.println("질문 ID = " + answer.getQuestionId() + ", 응답 = " + answer.getAnswer());
+                UUID qid = UUID.fromString(answer.getQuestionId());
+                if (!validQuestionIds.contains(qid)) {
+                    throw new IllegalArgumentException("유효하지 않은 질문 ID입니다: " + qid);
+                }
             }
+
+            //3.응답 및 질문 스냅샷 JSON 직렬화
+            String answersJson = toJson(request.getAnswers());
+            List<QuestionSnapshotDto> snapshot = survey.getQuestions().stream()
+                    .map(q -> new QuestionSnapshotDto(
+                            q.getId(),
+                            q.getTitle(),
+                            q.getDescription(),
+                            q.getType(),
+                            q.isRequired()
+                    ))
+                    .collect(Collectors.toList());
+
+            String snapshotJson = toJson(snapshot);
+
+            //4.저장
+            SurveyResponse response = new SurveyResponse(
+                    survey,
+                    answersJson,
+                    snapshotJson
+            );
+            surveyResponseRepository.save(response);
+        } catch (Exception e) {
+            e.printStackTrace();
+
+            throw new RuntimeException("응답 저장 중 에러 발생: " + e.getMessage(), e);
         }
-
-        // 3. 응답 및 질문 스냅샷 JSON 직렬화
-        String answersJson = toJson(request.getAnswers());
-        String snapshotJson = toJson(survey.getQuestions());
-
-        // 4. 저장
-        SurveyResponse response = new SurveyResponse(
-                survey.getId(),
-                answersJson,
-                snapshotJson
-        );
-        surveyResponseRepository.save(response);
     }
 
     private String toJson(Object obj) {

--- a/project/sumin-onboarding/survey-service/application/src/main/java/com/innercircle/survey/application/service/SurveyResponseService.java
+++ b/project/sumin-onboarding/survey-service/application/src/main/java/com/innercircle/survey/application/service/SurveyResponseService.java
@@ -1,0 +1,66 @@
+package com.innercircle.survey.application.service;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.innercircle.survey.common.dto.AnswerDto;
+import com.innercircle.survey.common.dto.SurveyResponseDto;
+import com.innercircle.survey.domain.entity.Question;
+import com.innercircle.survey.domain.entity.Survey;
+import com.innercircle.survey.domain.entity.SurveyResponse;
+import com.innercircle.survey.domain.repository.SurveyRepository;
+import com.innercircle.survey.domain.repository.SurveyResponseRepository;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.Set;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class SurveyResponseService {
+
+    private final SurveyRepository surveyRepository;
+    private final SurveyResponseRepository surveyResponseRepository;
+    private final ObjectMapper objectMapper;
+
+    public void submitResponse(SurveyResponseDto request) {
+        // 1. 설문 존재 여부 확인
+        Survey survey = surveyRepository.findById(request.getSurveyId())
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 설문입니다."));
+
+        // 2. 질문 ID 유효성 검증
+        Set<UUID> validQuestionIds = survey.getQuestions().stream()
+                .map(Question::getId)
+                .collect(Collectors.toSet());
+
+        for (AnswerDto answer : request.getAnswers()) {
+            UUID qid = UUID.fromString(answer.getQuestionId());
+            if (!validQuestionIds.contains(qid)) {
+                throw new IllegalArgumentException("유효하지 않은 질문 ID입니다: " + qid);
+            }
+        }
+
+        // 3. 응답 및 질문 스냅샷 JSON 직렬화
+        String answersJson = toJson(request.getAnswers());
+        String snapshotJson = toJson(survey.getQuestions());
+
+        // 4. 저장
+        SurveyResponse response = new SurveyResponse(
+                survey.getId(),
+                answersJson,
+                snapshotJson
+        );
+        surveyResponseRepository.save(response);
+    }
+
+    private String toJson(Object obj) {
+        try {
+            return objectMapper.writeValueAsString(obj);
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException("JSON 변환 실패", e);
+        }
+    }
+}

--- a/project/sumin-onboarding/survey-service/application/src/main/java/com/innercircle/survey/application/service/SurveyService.java
+++ b/project/sumin-onboarding/survey-service/application/src/main/java/com/innercircle/survey/application/service/SurveyService.java
@@ -2,18 +2,25 @@ package com.innercircle.survey.application.service;
 
 
 import com.innercircle.survey.common.dto.QuestionDto;
+import com.innercircle.survey.common.dto.QuestionUpdateDto;
 import com.innercircle.survey.common.dto.SurveyCreateDto;
+import com.innercircle.survey.common.dto.SurveyUpdateDto;
 import com.innercircle.survey.domain.entity.Question;
 import com.innercircle.survey.domain.entity.QuestionOption;
 import com.innercircle.survey.domain.entity.Survey;
 import com.innercircle.survey.domain.repository.SurveyRepository;
+import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import java.util.Map;
 import java.util.UUID;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
+@Transactional
 public class SurveyService {
     private final SurveyRepository surveyRepository;
 
@@ -46,4 +53,42 @@ public class SurveyService {
         return survey.getId(); // UUID 기준
     }
 
+    public void updateSurvey(UUID surveyId, SurveyUpdateDto dto) {
+        Survey survey = surveyRepository.findById(surveyId)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 설문입니다."));
+
+        //1.타이틀 및 설명 수정
+        survey.updateTitle(dto.getTitle());
+        survey.updateDescription(dto.getDescription());
+
+        // 2. 기존 질문 목록
+        Map<UUID, Question> existingQuestions = survey.getQuestions().stream()
+                .collect(Collectors.toMap(Question::getId, Function.identity()));
+
+        // 3. 새로 들어온 질문 목록 처리
+        for (QuestionUpdateDto questionDto : dto.getQuestions()) {
+            if (questionDto.getQuestionId() == null) {
+                // 새 질문 추가
+                Question newQuestion =Question.builder()
+                        .title(questionDto.getTitle())
+                        .description(questionDto.getDescription())
+                        .type(questionDto.getType())
+                        .required(questionDto.isRequired())
+                        .survey(survey) // 필요 시
+                        .build();
+                survey.addQuestion(newQuestion);
+            } else {
+                // 기존 질문 수정
+                Question existing = existingQuestions.remove(questionDto.getQuestionId());
+                if (existing != null) {
+                    existing.update(questionDto);
+                }
+            }
+        }
+
+        // 4. 삭제된 질문 제거 (남은 것들은 요청에서 빠졌다는 뜻)
+        for (Question q : existingQuestions.values()) {
+            survey.removeQuestion(q); // 필요 시 soft-delete
+        }
+    }
 }

--- a/project/sumin-onboarding/survey-service/application/src/main/java/com/innercircle/survey/application/service/SurveyService.java
+++ b/project/sumin-onboarding/survey-service/application/src/main/java/com/innercircle/survey/application/service/SurveyService.java
@@ -68,7 +68,7 @@ public class SurveyService {
         // 3. 새로 들어온 질문 목록 처리
         for (QuestionUpdateDto questionDto : dto.getQuestions()) {
             if (questionDto.getQuestionId() == null) {
-                // 새 질문 추가
+                //새 질문 추가
                 Question newQuestion =Question.builder()
                         .title(questionDto.getTitle())
                         .description(questionDto.getDescription())
@@ -76,9 +76,16 @@ public class SurveyService {
                         .required(questionDto.isRequired())
                         .survey(survey) // 필요 시
                         .build();
+                //옵션 리스트 추가
+                if (questionDto.getOptions() != null) {
+                    for (String option : questionDto.getOptions()) {
+                        QuestionOption qo = new QuestionOption(option, newQuestion);
+                        newQuestion.getOptions().add(qo);
+                    }
+                }
                 survey.addQuestion(newQuestion);
             } else {
-                // 기존 질문 수정
+                //기존 질문 수정
                 Question existing = existingQuestions.remove(questionDto.getQuestionId());
                 if (existing != null) {
                     existing.update(questionDto);

--- a/project/sumin-onboarding/survey-service/common/src/main/java/com/innercircle/survey/common/dto/AnswerDto.java
+++ b/project/sumin-onboarding/survey-service/common/src/main/java/com/innercircle/survey/common/dto/AnswerDto.java
@@ -1,0 +1,17 @@
+package com.innercircle.survey.common.dto;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.*;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class AnswerDto {
+
+    @NotNull(message = "질문 ID는 필수입니다.")
+    private String questionId;
+
+    @NotNull(message = "응답 값은 필수입니다.")
+    private String answer;
+}

--- a/project/sumin-onboarding/survey-service/common/src/main/java/com/innercircle/survey/common/dto/QuestionSnapshotDto.java
+++ b/project/sumin-onboarding/survey-service/common/src/main/java/com/innercircle/survey/common/dto/QuestionSnapshotDto.java
@@ -1,0 +1,11 @@
+package com.innercircle.survey.common.dto;
+
+import java.util.UUID;
+
+public record QuestionSnapshotDto(
+        UUID id,
+        String title,
+        String description,
+        String type,
+        boolean required
+) {}

--- a/project/sumin-onboarding/survey-service/common/src/main/java/com/innercircle/survey/common/dto/QuestionUpdateDto.java
+++ b/project/sumin-onboarding/survey-service/common/src/main/java/com/innercircle/survey/common/dto/QuestionUpdateDto.java
@@ -4,25 +4,28 @@ import jakarta.validation.constraints.NotNull;
 import lombok.*;
 
 import java.util.List;
+import java.util.UUID;
 
-//설문 받을 항목 DTO
 @Data
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
 @Getter
-public class QuestionDto {
-    //항목 이름
+public class QuestionUpdateDto {
+    // 기존 질문 수정 시 필요. 새로 추가된 질문은 null 가능
+    private UUID questionId;
+
     @NotNull(message = "질문 제목은 필수입니다.")
     private String title;
-    //항목 설명
+
     private String description;
-    //항목 입력 형태
-    @NotNull(message = "질문 입력 형태는 필수입니다.")
+
+    @NotNull(message = "질문 타입은 필수입니다.")
     private String type;
-    //항목 필수 여부
+
     private boolean required;
-    //선택 질문 옵션
+
+    // 단/복수 선택일 때
     private List<String> options;
 
 }

--- a/project/sumin-onboarding/survey-service/common/src/main/java/com/innercircle/survey/common/dto/SurveyResponseDto.java
+++ b/project/sumin-onboarding/survey-service/common/src/main/java/com/innercircle/survey/common/dto/SurveyResponseDto.java
@@ -1,0 +1,23 @@
+package com.innercircle.survey.common.dto;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import lombok.*;
+
+import java.util.List;
+import java.util.UUID;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class SurveyResponseDto {
+
+    @NotNull(message = "설문 ID는 필수입니다.")
+    private UUID surveyId;
+
+    @NotEmpty(message = "응답은 최소 1개 이상 있어야 합니다.")
+    @Valid
+    private List<AnswerDto> answers;
+}

--- a/project/sumin-onboarding/survey-service/common/src/main/java/com/innercircle/survey/common/dto/SurveyUpdateDto.java
+++ b/project/sumin-onboarding/survey-service/common/src/main/java/com/innercircle/survey/common/dto/SurveyUpdateDto.java
@@ -1,0 +1,27 @@
+package com.innercircle.survey.common.dto;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+import java.util.UUID;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class SurveyUpdateDto {
+    @NotNull(message = "설문 제목은 필수입니다.")
+    private String title;
+
+    private String description;
+
+    @Size(min = 1, max = 10, message = "질문은 1개 이상 10개 이하입니다.")
+    @Valid
+    private List<QuestionUpdateDto> questions;;
+}

--- a/project/sumin-onboarding/survey-service/domain/build.gradle.kts
+++ b/project/sumin-onboarding/survey-service/domain/build.gradle.kts
@@ -3,6 +3,8 @@ plugins {
 }
 
 dependencies {
+    implementation(project(":common"))
+
     implementation("jakarta.persistence:jakarta.persistence-api:3.1.0")
     implementation("org.springframework.boot:spring-boot-starter-data-jpa")
 

--- a/project/sumin-onboarding/survey-service/domain/src/main/java/com/innercircle/survey/domain/entity/Question.java
+++ b/project/sumin-onboarding/survey-service/domain/src/main/java/com/innercircle/survey/domain/entity/Question.java
@@ -1,15 +1,14 @@
 package com.innercircle.survey.domain.entity;
 
+import com.innercircle.survey.common.dto.QuestionUpdateDto;
 import jakarta.persistence.*;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+import java.util.UUID;
 
 @Entity
 @Getter
@@ -20,7 +19,7 @@ public class Question {
     //질문 ID(PK)
     @Id
     @GeneratedValue
-    private Long id;
+    private UUID id;
 
     //질문 제목
     private String title;
@@ -35,6 +34,7 @@ public class Question {
     private boolean required;
 
     //설문조사와 N:1
+    @Setter
     @ManyToOne
     @JoinColumn(name = "survey_id")
     private Survey survey;
@@ -56,4 +56,10 @@ public class Question {
     //질문 수정시간
     private LocalDateTime updatedAt;
 
+    public void update(QuestionUpdateDto questionDto) {
+        this.title = questionDto.getTitle();
+        this.description = questionDto.getDescription();
+        this.type = questionDto.getType();
+        this.required = questionDto.isRequired();
+    }
 }

--- a/project/sumin-onboarding/survey-service/domain/src/main/java/com/innercircle/survey/domain/entity/Question.java
+++ b/project/sumin-onboarding/survey-service/domain/src/main/java/com/innercircle/survey/domain/entity/Question.java
@@ -6,7 +6,6 @@ import lombok.*;
 
 import java.time.LocalDateTime;
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.List;
 import java.util.UUID;
 
@@ -42,7 +41,7 @@ public class Question {
     //선택 리스트와 1:N
     @Builder.Default
     @OneToMany(mappedBy = "question", cascade = CascadeType.ALL, orphanRemoval = true)
-    private List<QuestionOption> options = new ArrayList<QuestionOption>();
+    private List<QuestionOption> options = new ArrayList<>();
 
     //질문 생성자
     private String createdBy;

--- a/project/sumin-onboarding/survey-service/domain/src/main/java/com/innercircle/survey/domain/entity/Survey.java
+++ b/project/sumin-onboarding/survey-service/domain/src/main/java/com/innercircle/survey/domain/entity/Survey.java
@@ -64,6 +64,6 @@ public class Survey {
 
     public void removeQuestion(Question q) {
         questions.remove(q);
-        q.setSurvey(null); // 양방향 관계 해제
+        q.setSurvey(null);
     }
 }

--- a/project/sumin-onboarding/survey-service/domain/src/main/java/com/innercircle/survey/domain/entity/Survey.java
+++ b/project/sumin-onboarding/survey-service/domain/src/main/java/com/innercircle/survey/domain/entity/Survey.java
@@ -45,4 +45,25 @@ public class Survey {
 
     //설문조사 수정시간
     private LocalDateTime updatedAt;
+
+    public void updateTitle(String title) {
+        if (title == null || title.isBlank()) {
+            throw new IllegalArgumentException("설문 제목은 비어 있을 수 없습니다.");
+        }
+        this.title = title;
+    }
+
+    public void updateDescription(String description) {
+        this.description = description;
+    }
+
+    public void addQuestion(Question newQuestion) {
+        this.questions.add(newQuestion);       // 설문 → 질문 추가
+        newQuestion.setSurvey(this);           // 질문 → 설문 설정 (양방향 연관관계 유지)
+    }
+
+    public void removeQuestion(Question q) {
+        questions.remove(q);
+        q.setSurvey(null); // 양방향 관계 해제
+    }
 }

--- a/project/sumin-onboarding/survey-service/domain/src/main/java/com/innercircle/survey/domain/entity/SurveyResponse.java
+++ b/project/sumin-onboarding/survey-service/domain/src/main/java/com/innercircle/survey/domain/entity/SurveyResponse.java
@@ -1,0 +1,4 @@
+package com.innercircle.survey.domain.entity;
+
+public class SurveyResponse {
+}

--- a/project/sumin-onboarding/survey-service/domain/src/main/java/com/innercircle/survey/domain/entity/SurveyResponse.java
+++ b/project/sumin-onboarding/survey-service/domain/src/main/java/com/innercircle/survey/domain/entity/SurveyResponse.java
@@ -1,7 +1,6 @@
 package com.innercircle.survey.domain.entity;
 
 import jakarta.persistence.*;
-import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -18,15 +17,16 @@ public class SurveyResponse {
     @GeneratedValue(strategy = GenerationType.UUID)
     private UUID id;
 
-    @Column(nullable = false)
-    private UUID surveyId;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "survey_id", nullable = false)
+    private Survey survey;
 
     //제출된 응답들(JSON)
     @Lob
     @Column(nullable = false)
     private String answersJson;
 
-    //당시 질문 스냅샷(JSON)
+    //질문 스냅샷(JSON)
     @Lob
     @Column(nullable = false)
     private String snapshotJson;
@@ -39,8 +39,8 @@ public class SurveyResponse {
         this.submittedAt = LocalDateTime.now();
     }
 
-    public SurveyResponse(UUID surveyId, String answersJson, String snapshotJson) {
-        this.surveyId = surveyId;
+    public SurveyResponse(Survey survey, String answersJson, String snapshotJson) {
+        this.survey = survey;
         this.answersJson = answersJson;
         this.snapshotJson = snapshotJson;
     }

--- a/project/sumin-onboarding/survey-service/domain/src/main/java/com/innercircle/survey/domain/entity/SurveyResponse.java
+++ b/project/sumin-onboarding/survey-service/domain/src/main/java/com/innercircle/survey/domain/entity/SurveyResponse.java
@@ -1,4 +1,47 @@
 package com.innercircle.survey.domain.entity;
 
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Entity
+@Table(name = "survey_response")
+@Getter
+@NoArgsConstructor
 public class SurveyResponse {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private UUID id;
+
+    @Column(nullable = false)
+    private UUID surveyId;
+
+    //제출된 응답들(JSON)
+    @Lob
+    @Column(nullable = false)
+    private String answersJson;
+
+    //당시 질문 스냅샷(JSON)
+    @Lob
+    @Column(nullable = false)
+    private String snapshotJson;
+
+    @Column(nullable = false, updatable = false)
+    private LocalDateTime submittedAt;
+
+    @PrePersist
+    public void prePersist() {
+        this.submittedAt = LocalDateTime.now();
+    }
+
+    public SurveyResponse(UUID surveyId, String answersJson, String snapshotJson) {
+        this.surveyId = surveyId;
+        this.answersJson = answersJson;
+        this.snapshotJson = snapshotJson;
+    }
 }

--- a/project/sumin-onboarding/survey-service/domain/src/main/java/com/innercircle/survey/domain/repository/SurveyResponseRepository.java
+++ b/project/sumin-onboarding/survey-service/domain/src/main/java/com/innercircle/survey/domain/repository/SurveyResponseRepository.java
@@ -1,0 +1,10 @@
+package com.innercircle.survey.domain.repository;
+
+import com.innercircle.survey.domain.entity.Survey;
+import com.innercircle.survey.domain.entity.SurveyResponse;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.UUID;
+
+public interface SurveyResponseRepository extends JpaRepository<SurveyResponse, UUID> {
+}


### PR DESCRIPTION
## Goal
설문 수정 API 및 설문 응답 제출 API 구현
설문 항목 변경 시 기존 응답 보존을 위한 스냅샷 저장 구조 도입

## Changes
-설문 수정용 및 응답 제출용 DTO 설계
-설문 수정 API 구현: 항목 추가/수정/삭제 가능, 기존 응답 영향 없음
-응답 제출 API 구현: 제출 시점 기준 설문 항목 정보를 스냅샷(JSON)으로 저장
-SurveyResponse 엔티티에 answersJson, snapshotJson, survey 연관관계 추가
-응답 제출 서비스 및 컨트롤러 작성
-Jackson ObjectMapper를 활용한 스냅샷 직렬화

## Description
설문 수정 시, 질문 리스트(이름, 설명, 타입, 필수 여부)를 변경할 수 있는 API를 구현했습니다.
설문에 응답할 때는 각 질문에 대한 답변을 answersJson, 질문 정보는 snapshotJson에 각각 JSON으로 저장합니다.
현재는 JSON 기반이지만, 검색 기능 또는 통계 처리 필요 시 정규화된 구조도 고려할 예정입니다.

## Additional Context (Optional)


## Screenshots/Videos (Optional)


## References (Optional)

