### PR TITLE
설문 응답 조회 API 구현

### DIFF
--- a/project/sumin-onboarding/survey-service/api/src/main/java/com/innercircle/survey/api/controller/SurveyResponseController.java
+++ b/project/sumin-onboarding/survey-service/api/src/main/java/com/innercircle/survey/api/controller/SurveyResponseController.java
@@ -1,6 +1,7 @@
 package com.innercircle.survey.api.controller;
 
 import com.innercircle.survey.application.service.SurveyResponseService;
+import com.innercircle.survey.common.dto.SurveyResponseDetailDto;
 import com.innercircle.survey.common.dto.SurveyResponseDto;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -16,6 +17,7 @@ public class SurveyResponseController {
 
     private final SurveyResponseService surveyResponseService;
 
+    //응답 제출
     @PostMapping("/{surveyId}/responses")
     public ResponseEntity<Void> submitSurveyResponse(
             @PathVariable UUID surveyId,
@@ -25,5 +27,12 @@ public class SurveyResponseController {
 
         surveyResponseService.submitResponse(request);
         return ResponseEntity.ok().build();
+    }
+
+    //응답 조회
+    @GetMapping("/responses/{responseId}")
+    public ResponseEntity<SurveyResponseDetailDto> getResponse(@PathVariable UUID responseId) {
+        SurveyResponseDetailDto result = surveyResponseService.getSurveyResponse(responseId);
+        return ResponseEntity.ok(result);
     }
 }

--- a/project/sumin-onboarding/survey-service/common/src/main/java/com/innercircle/survey/common/dto/SurveyResponseDetailDto.java
+++ b/project/sumin-onboarding/survey-service/common/src/main/java/com/innercircle/survey/common/dto/SurveyResponseDetailDto.java
@@ -1,0 +1,19 @@
+package com.innercircle.survey.common.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class SurveyResponseDetailDto {
+    private UUID id;
+    private LocalDateTime submittedAt;
+    private List<QuestionSnapshotDto> snapshot;
+    private List<AnswerDto> answers;
+}


### PR DESCRIPTION
## Goal
설문 응답 조회 API를 구현하여, 응답 시점의 질문 스냅샷과 사용자의 응답 데이터를 함께 확인할 수 있도록 함

## Changes
SurveyResponseController에 응답 단건 조회 API (GET /api/surveys/{surveyId}/responses/{responseId}) 추가
SurveyResponseService에서 JSON 형태로 저장된 answersJson, snapshotJson 필드 파싱
응답 결과를 SurveyResponseResultDto로 매핑하여 반환

## Description
설문 응답 제출 시점의 질문 리스트를 JSON으로 저장하고, 해당 스냅샷 및 응답 데이터를 그대로 조회 응답에 포함되도록 구현함
파싱은 ObjectMapper를 사용하여 DTO로 deserialize
조회 시 질문 ID, 제목, 타입 등의 메타데이터를 포함한 응답 결과 제공

## Additional Context (Optional)
- 응답 데이터에 대해 정규화 테이블(`response_answer`, `response_question`) 도입 예정

## Screenshots/Videos (Optional)


## References (Optional)


